### PR TITLE
Moved code mappings to api

### DIFF
--- a/roborock/__init__.py
+++ b/roborock/__init__.py
@@ -4,3 +4,4 @@ from roborock.api import RoborockClient, RoborockMqttClient
 from roborock.containers import *
 from roborock.exceptions import *
 from roborock.typing import *
+from roborock.code_mappings import *

--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -1,0 +1,80 @@
+STATE_CODE_TO_STATUS = {
+    1: "starting",
+    2: "charger_disconnected",
+    3: "idle",
+    4: "remote_control_active",
+    5: "cleaning",
+    6: "returning_home",
+    7: "manual_mode",
+    8: "charging",
+    9: "charging_problem",
+    10: "paused",
+    11: "spot_cleaning",
+    12: "error",
+    13: "shutting_down",
+    14: "updating",
+    15: "docking",
+    16: "going_to_target",
+    17: "zoned_cleaning",
+    18: "segment_cleaning",
+    22: "emptying_the_bin",  # on s7+, see #1189
+    23: "washing_the_mop",  # on a46, #1435
+    26: "going_to_wash_the_mop",  # on a46, #1435
+    100: "charging_complete",
+    101: "device_offline",
+}
+
+ERROR_CODE_TO_TEXT = {
+    0: "None",
+    1: "LiDAR turret or laser blocked. Check for obstruction and retry.",
+    2: "Bumper stuck. Clean it and lightly tap to release it.",
+    3: "Wheels suspended. Move robot and restart.",
+    4: "Cliff sensor error. Clean cliff sensors, move robot away from drops and restart.",
+    5: "Main brush jammed. Clean main brush and bearings.",
+    6: "Side brush jammed. Remove and clean side brush.",
+    7: "Wheels jammed. Move the robot and restart.",
+    8: "Robot trapped. Clear obstacles surrounding robot.",
+    9: "No dustbin. Install dustbin and filter.",
+    12: "Low battery. Recharge and retry.",
+    13: "Charging error. Clean charging contacts and retry.",
+    14: "Battery error.",
+    15: "Wall sensor dirty. Clean wall sensor.",
+    16: "Robot tilted. Move to level ground and restart.",
+    17: "Side brush error. Reset robot.",
+    18: "Fan error. Reset robot.",
+    21: "Vertical bumper pressed. Move robot and retry.",
+    22: "Dock locator error. Clean and retry.",
+    23: "Could not return to dock. Clean dock location beacon and retry.",
+    24: "No-go zone or invisible wall detected. Move the robot.",
+    27: "VibraRise system jammed. Check for obstructions.",
+    28: "Robot on carpet. Move robot to floor and retry.",
+    29: "Filter blocked or wet. Clean, dry, and retry.",
+    30: "No-go zone or Invisible Wall detected. Move robot from this area.",
+    31: "Cannot cross carpet. Move robot across carpet and restart.",
+    32: "Internal error. Reset the robot.",
+}
+
+FAN_SPEED_CODES = {
+    105: "off",
+    101: "silent",
+    102: "balanced",
+    103: "turbo",
+    104: "max",
+    108: "max_plus",
+    106: "custom",
+}
+
+MOP_MODE_CODES = {
+    300: "standard",
+    301: "deep",
+    303: "deep_plus",
+    302: "custom",
+}
+
+MOP_INTENSITY_CODES = {
+    200: "off",
+    201: "mild",
+    202: "moderate",
+    203: "intense",
+    204: "custom",
+}

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -1,5 +1,8 @@
 from enum import Enum
 
+from roborock.code_mappings import STATE_CODE_TO_STATUS, ERROR_CODE_TO_TEXT, FAN_SPEED_CODES, MOP_MODE_CODES, \
+    MOP_INTENSITY_CODES
+
 
 class UserDataRRiotReferenceField(str, Enum):
     REGION = "r"
@@ -630,6 +633,10 @@ class Status(RoborockBase):
         return self.get(StatusField.MSG_SEQ)
 
     @property
+    def status(self) -> str:
+        return STATE_CODE_TO_STATUS.get(self.state, f"Unknown Status {self.state}")
+
+    @property
     def state(self) -> int:
         return self.get(StatusField.STATE)
 
@@ -648,6 +655,10 @@ class Status(RoborockBase):
     @property
     def error_code(self) -> int:
         return self.get(StatusField.ERROR_CODE)
+
+    @property
+    def error(self) -> str:
+        return ERROR_CODE_TO_TEXT.get(self.error_code, f"Unknown Error {self.error_code}")
 
     @property
     def map_present(self) -> int:
@@ -686,8 +697,12 @@ class Status(RoborockBase):
         return self.get(StatusField.WASH_READY)
 
     @property
-    def fan_power(self) -> int:
+    def fan_power_code(self) -> int:
         return self.get(StatusField.FAN_POWER)
+
+    @property
+    def fan_power(self) -> str:
+        return FAN_SPEED_CODES.get(self.fan_power_code, f"Unknown power {self.fan_power_code}")
 
     @property
     def dnd_enabled(self) -> int:
@@ -708,6 +723,10 @@ class Status(RoborockBase):
     @property
     def water_box_mode(self) -> int:
         return self.get(StatusField.WATER_BOX_MODE)
+
+    @property
+    def mop_intensity(self) -> str:
+        return MOP_INTENSITY_CODES.get(self.water_box_mode, f"Unknown intensity {self.water_box_mode}")
 
     @property
     def water_box_carriage_status(self) -> int:
@@ -758,8 +777,12 @@ class Status(RoborockBase):
         return self.get(StatusField.AVOID_COUNT)
 
     @property
-    def mop_mode(self) -> int:
+    def mop_mode_code(self) -> int:
         return self.get(StatusField.MOP_MODE)
+
+    @property
+    def mop_mode(self) -> str:
+        return MOP_MODE_CODES.get(self.mop_mode_code, f"Unknown mop mode {self.mop_mode_code}")
 
     @property
     def debug_mode(self) -> int:

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -634,7 +634,7 @@ class Status(RoborockBase):
 
     @property
     def status(self) -> str:
-        return STATE_CODE_TO_STATUS.get(self.state, f"Unknown Status {self.state}")
+        return STATE_CODE_TO_STATUS.get(self.state)
 
     @property
     def state(self) -> int:
@@ -658,7 +658,7 @@ class Status(RoborockBase):
 
     @property
     def error(self) -> str:
-        return ERROR_CODE_TO_TEXT.get(self.error_code, f"Unknown Error {self.error_code}")
+        return ERROR_CODE_TO_TEXT.get(self.error_code)
 
     @property
     def map_present(self) -> int:
@@ -702,7 +702,7 @@ class Status(RoborockBase):
 
     @property
     def fan_power(self) -> str:
-        return FAN_SPEED_CODES.get(self.fan_power_code, f"Unknown power {self.fan_power_code}")
+        return FAN_SPEED_CODES.get(self.fan_power_code)
 
     @property
     def dnd_enabled(self) -> int:
@@ -726,7 +726,7 @@ class Status(RoborockBase):
 
     @property
     def mop_intensity(self) -> str:
-        return MOP_INTENSITY_CODES.get(self.water_box_mode, f"Unknown intensity {self.water_box_mode}")
+        return MOP_INTENSITY_CODES.get(self.water_box_mode)
 
     @property
     def water_box_carriage_status(self) -> int:
@@ -782,7 +782,7 @@ class Status(RoborockBase):
 
     @property
     def mop_mode(self) -> str:
-        return MOP_MODE_CODES.get(self.mop_mode_code, f"Unknown mop mode {self.mop_mode_code}")
+        return MOP_MODE_CODES.get(self.mop_mode_code)
 
     @property
     def debug_mode(self) -> int:


### PR DESCRIPTION
Getting an integration approved in HA is complicated. The larger the PR, the less likely it will be to be reviewed at any time soon. 

So I moved the code mappings to the api to decrease the file size of vacuum.py.

We don't have to do this if you are against this. 

This is a breaking change for the hacs integration. unless I make the same changes over there.

Let me know your thoughts.