### PR TITLE
Change to timeout from wait_for

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ roborock = "roborock.cli:main"
 python = "^3.8"
 click = ">=8"
 aiohttp = "*"
+async-timeout = "*"
 pycryptodome = "~3.16.0"
 pycryptodomex = {version = "~3.16.0", markers = "sys_platform == 'darwin'"}
 paho-mqtt = "~1.6.1"

--- a/roborock/roborock_queue.py
+++ b/roborock/roborock_queue.py
@@ -18,5 +18,4 @@ class RoborockQueue(Queue):
 
     async def async_get(self, timeout: float | int) -> tuple[Any, RoborockException | None]:
         async with async_timeout.timeout(timeout):
-            await self.get()
-        return await asyncio.wait_for(self.get(), timeout=timeout)
+            return await self.get()

--- a/roborock/roborock_queue.py
+++ b/roborock/roborock_queue.py
@@ -1,6 +1,7 @@
 import asyncio
 from asyncio import Queue
 from typing import Any
+import async_timeout
 
 from roborock import RoborockException
 
@@ -12,7 +13,10 @@ class RoborockQueue(Queue):
         self.protocol = protocol
 
     async def async_put(self, item: tuple[Any, RoborockException | None], timeout: float | int) -> None:
-        return await asyncio.wait_for(self.put(item), timeout=timeout)
+        async with async_timeout.timeout(timeout):
+            await self.put(item)
 
     async def async_get(self, timeout: float | int) -> tuple[Any, RoborockException | None]:
+        async with async_timeout.timeout(timeout):
+            await self.get()
         return await asyncio.wait_for(self.get(), timeout=timeout)


### PR DESCRIPTION
wait_for creates a task, async_timeout does the same work and avoids the task creation

This is one of the current optimizations they are making on HA core.

Sorry to be making so many PRS!