### PR TITLE
Remove circular dependenacy

### DIFF
--- a/roborock/roborock_queue.py
+++ b/roborock/roborock_queue.py
@@ -2,7 +2,7 @@ import asyncio
 from asyncio import Queue
 from typing import Any
 
-from roborock import RoborockException
+from .exceptions import RoborockException
 
 
 class RoborockQueue(Queue):


### PR DESCRIPTION
Accidentally introduced this when I was adding typing