### PR TITLE
feat: Add automatic release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,5 @@ jobs:
             -   name: Python Semantic Release
                 uses: relekang/python-semantic-release@v7.33.2
                 with:
-                    github_token: ${{ secrets.GITHUB_TOKEN }}
+                    github_token: ${{ secrets.GH_TOKEN }}
                     pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,17 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    # Make sure commit messages follow the conventional commits convention:
+    # https://www.conventionalcommits.org
+    commitlint:
+        name: Lint Commit Messages
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0
+            -   uses: wagoid/commitlint-github-action@v5.3.0
+
     test:
         strategy:
             fail-fast: false
@@ -36,3 +47,26 @@ jobs:
             -   name: Test with Pytest
                 run: poetry run pytest
                 shell: bash
+    release:
+        runs-on: ubuntu-latest
+        environment: release
+        if: github.ref == 'refs/heads/main'
+        needs:
+            - test
+
+        steps:
+            -   uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0
+
+            # Run semantic release:
+            # - Update CHANGELOG.md
+            # - Update version in code
+            # - Create git tag
+            # - Create GitHub release
+            # - Publish to PyPI
+            -   name: Python Semantic Release
+                uses: relekang/python-semantic-release@v7.33.2
+                with:
+                    github_token: ${{ secrets.GITHUB_TOKEN }}
+                    pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,8 @@ build-backend = "poetry.core.masonry.api"
 pytest-asyncio = "*"
 pytest = "*"
 
+[tool.semantic_release]
+branch = "main"
+version_toml = "pyproject.toml:tool.poetry.version"
+version_variable = "setup.py:__version__"
+build_command = "pip install poetry && poetry build"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 import setuptools
 
-__version__ = "0.0.0"
+__version__ = "0.1.10"
 
 if __name__ == "__main__":
     setuptools.setup(name="roborock", version=__version__)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+# This is a shim to allow GitHub to detect the package, build is done with poetry
+# Taken from https://github.com/Textualize/rich
+
+import setuptools
+
+__version__ = "0.0.0"
+
+if __name__ == "__main__":
+    setuptools.setup(name="roborock", version=__version__)


### PR DESCRIPTION
So - this is something I've done for a few other pypi projects, but I've never done it in the middle of the project like this. So it may take some testing/ tuning.

You'll have to get an access token for pypi https://test.pypi.org/help/#apitoken

and a github token. And allow actions permissions to write on the repository.

This will when you merge into main, automatically create a changelog, bump the version, put out a release on github, and then put out a pypi release.

We need a changelog for HA core.

It means we should tag our commits with chore: (something small, doesn't need a version bump)

fix: Fixes an existing bump, needs a small version bump

feat: A new feature

If you don't want to do this, that is fine, but we do need to create a changelog at some point for HA if nothing else.

I'd add this one before the other PR as I manually set the version to catch up with the last one.