### PR TITLE
fix: changed prefix for set_custom_mode

### DIFF
--- a/roborock/typing.py
+++ b/roborock/typing.py
@@ -115,7 +115,7 @@ class CommandInfo:
 CommandInfoMap: dict[RoborockCommand, CommandInfo] = {
     RoborockCommand.GET_PROP: CommandInfo(prefix=b'\x00\x00\x00\x87'),
     RoborockCommand.GET_STATUS: CommandInfo(prefix=b'\x00\x00\x00\x77'),
-    RoborockCommand.SET_CUSTOM_MODE: CommandInfo(prefix=b'\x00\x00\x00\x87'),
+    RoborockCommand.SET_CUSTOM_MODE: CommandInfo(prefix=b'\x00\x00\x00w'),
     RoborockCommand.GET_CHILD_LOCK_STATUS: CommandInfo(prefix=b'\x00\x00\x00\x87'),
     RoborockCommand.GET_MULTI_MAPS_LIST: CommandInfo(prefix=b'\x00\x00\x00\x87'),
     RoborockCommand.GET_IDENTIFY_FURNITURE_STATUS: CommandInfo(prefix=b'\x00\x00\x00\x87'),


### PR DESCRIPTION
I connected to my phone through wireshark, and the prefix for custom mode was x00w not x00\x87.

I was timing out and the command would end up sending after 10 seconds, but with this fix, it is instant.

If you merge this and #27 in, I think I have fixed all of the bugs for the core version (outside of the dict issues, but I'm not sure if there are any direct bugs from that.