### PR TITLE
fix: removed enum type check

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -245,8 +245,6 @@ class RoborockClient:
         """Gets the status summary from the dock with the methods available for a given dock.
 
         :param dock_type: RoborockDockTypeCode"""
-        if RoborockDockTypeCode.name != "RoborockDockTypeCode":
-            raise RoborockException("Invalid enum given for dock type")
         try:
             commands: list[
                 Coroutine[


### PR DESCRIPTION
related to https://github.com/humbertogontijo/homeassistant-roborock/issues/245

I added this when I was fixing things with mypy - but it seems like it isn't actually being passed as the enum, and it isn't worth taking the time to fully debug as the check was mainly just a dev check and not a user check.