### PR TITLE
Clean summary for old devices

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -190,8 +190,8 @@ class RoborockClient:
             clean_summary = await self.send_command(device_id, RoborockCommand.GET_CLEAN_SUMMARY)
             if isinstance(clean_summary, dict):
                 return CleanSummary.from_dict(clean_summary)
-            elif isinstance(clean_summary, int):
-                return CleanSummary(clean_time=clean_summary)
+            elif isinstance(clean_summary, list):
+                return CleanSummary(clean_time=clean_summary[0], clean_area=clean_summary[1], clean_count=clean_summary[2], records=clean_summary[3])
         except RoborockTimeout as e:
             _LOGGER.error(e)
         return None


### PR DESCRIPTION
Example output of get_clean_summary
`2023-04-20 16:59:31.631 DEBUG (MainThread) [roborock.cloud_api] id=44374 Response from get_clean_summary: [297526, 4309707500, 260, [1681952400, 1681866001, 1681779601, 1681693200, 1681645328, 1681641905, 1681606801, 1681520401, 1681434001, 1681347601, 1681261201, 1681174801, 1681088401, 1681002002, 1680915601, 1680829200, 1680742801, 1680656401, 1680570001, 1680483600]]`

Values are 297526=Total Time in seconds, 4309707500=Total Area, 260=Cycles

Fixes: https://github.com/humbertogontijo/homeassistant-roborock/issues/245 and https://github.com/humbertogontijo/homeassistant-roborock/issues/117