### PR TITLE
feat: add support for old mop and vacuum codes

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -35,7 +35,7 @@ from .containers import (
     SmartWashParams,
     Status,
     UserData,
-    WashTowelMode,
+    WashTowelMode, StatusOldModes,
 )
 from .exceptions import (
     RoborockAccountDoesNotExist,
@@ -206,6 +206,8 @@ class RoborockClient:
     async def get_status(self, device_id: str) -> Status | None:
         status = await self.send_command(device_id, RoborockCommand.GET_STATUS)
         if isinstance(status, dict):
+            if self.devices_info[device_id].device.uses_old_codes:
+                return StatusOldModes.from_dict(status)
             return Status.from_dict(status)
         return None
 

--- a/roborock/api.py
+++ b/roborock/api.py
@@ -34,8 +34,9 @@ from .containers import (
     RoomMapping,
     SmartWashParams,
     Status,
+    StatusOldModes,
     UserData,
-    WashTowelMode, StatusOldModes,
+    WashTowelMode,
 )
 from .exceptions import (
     RoborockAccountDoesNotExist,

--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -160,14 +160,7 @@ RoborockDockErrorCode = create_code_enum(
 
 RoborockDockTypeCode = create_code_enum(
     "RoborockDockTypeCode",
-    {
-        0: "no_dock",
-        1: "unknown",
-        2: "unknown",
-        3: "empty_wash_fill_dock",
-        4: "unknown",
-        5: "auto_empty_dock_pure"
-    },
+    {0: "no_dock", 1: "unknown", 2: "unknown", 3: "empty_wash_fill_dock", 4: "unknown", 5: "auto_empty_dock_pure"},
 )
 
 RoborockDockDustCollectionModeCode = create_code_enum(
@@ -191,23 +184,9 @@ RoborockDockWashTowelModeCode = create_code_enum(
 
 OldRoborockFanPowerCode = create_code_enum(
     "OldRoborockFanPowerCode",
-    {
-        101: "silent",
-        102: "balanced",
-        103: "turbo",
-        104: "max",
-        105: "gentle",
-        106: "customize (auto)"
-    }
+    {101: "silent", 102: "balanced", 103: "turbo", 104: "max", 105: "gentle", 106: "customize (auto)"},
 )
 
 OldRoborockMopIntensityCode = create_code_enum(
-    "OldRoborockMopModeCode",
-    {
-        200: "off",
-        201: "low",
-        202: "medium",
-        203: "high",
-        207: "custom (levels)"
-    }
+    "OldRoborockMopModeCode", {200: "off", 201: "low", 202: "medium", 203: "high", 207: "custom (levels)"}
 )

--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -160,7 +160,14 @@ RoborockDockErrorCode = create_code_enum(
 
 RoborockDockTypeCode = create_code_enum(
     "RoborockDockTypeCode",
-    {0: "no_dock", 1: "unknown", 2: "unknown", 3: "empty_wash_fill_dock", 4: "unknown", 5: "auto_empty_dock_pure"},
+    {
+        0: "no_dock",
+        1: "unknown",
+        2: "unknown",
+        3: "empty_wash_fill_dock",
+        4: "unknown",
+        5: "auto_empty_dock_pure"
+    },
 )
 
 RoborockDockDustCollectionModeCode = create_code_enum(
@@ -180,4 +187,27 @@ RoborockDockWashTowelModeCode = create_code_enum(
         1: "balanced",
         2: "deep",
     },
+)
+
+OldRoborockFanPowerCode = create_code_enum(
+    "OldRoborockFanPowerCode",
+    {
+        101: "silent",
+        102: "balanced",
+        103: "turbo",
+        104: "max",
+        105: "gentle",
+        106: "customize (auto)"
+    }
+)
+
+OldRoborockMopIntensityCode = create_code_enum(
+    "OldRoborockMopModeCode",
+    {
+        200: "off",
+        201: "low",
+        202: "medium",
+        203: "high",
+        207: "custom (levels)"
+    }
 )

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -127,7 +127,7 @@ class HomeDataDeviceStatus(RoborockBase):
     id: Optional[Any] = None
     name: Optional[Any] = None
     code: Optional[Any] = None
-    model: Optional[Any] = None
+    model: Optional[str] = None
     icon_url: Optional[Any] = None
     attribute: Optional[Any] = None
     capability: Optional[Any] = None
@@ -165,7 +165,7 @@ class HomeDataDevice(RoborockBase):
     uses_old_codes: bool = False
 
     def __post_init__(self):
-        if self.device_status.model == "roborock.vacuum.a10":
+        if self.device_status and self.device_status.model == "roborock.vacuum.a10":
             self.uses_old_codes = True
 
 

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -20,6 +20,8 @@ from .code_mappings import (
     RoborockErrorCode,
     RoborockFanPowerCode,
     RoborockMopModeCode,
+    OldRoborockFanPowerCode,
+    OldRoborockMopIntensityCode,
 )
 from .const import FILTER_REPLACE_TIME, MAIN_BRUSH_REPLACE_TIME, SENSOR_DIRTY_REPLACE_TIME, SIDE_BRUSH_REPLACE_TIME
 
@@ -160,6 +162,11 @@ class HomeDataDevice(RoborockBase):
     new_feature_set: Optional[str] = None
     device_status: Optional[HomeDataDeviceStatus] = None
     silent_ota_switch: Optional[bool] = None
+    uses_old_codes: bool = False
+
+    def __post_init__(self):
+        if self.device_status.model == "roborock.vacuum.a10":
+            self.uses_old_codes = True
 
 
 @dataclass
@@ -233,6 +240,10 @@ class Status(RoborockBase):
     charge_status: Optional[int] = None
     unsave_map_reason: Optional[int] = None
     unsave_map_flag: Optional[int] = None
+
+class StatusOldModes(Status):
+    water_box_mode: Optional[OldRoborockMopIntensityCode] = None  # type: ignore[valid-type]
+    fan_power: Optional[OldRoborockFanPowerCode] = None  # type: ignore[valid-type]
 
 
 @dataclass

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -15,13 +15,13 @@ from roborock.code_mappings import (
 )
 
 from .code_mappings import (
+    OldRoborockFanPowerCode,
+    OldRoborockMopIntensityCode,
     RoborockDockDustCollectionModeCode,
     RoborockDockErrorCode,
     RoborockErrorCode,
     RoborockFanPowerCode,
     RoborockMopModeCode,
-    OldRoborockFanPowerCode,
-    OldRoborockMopIntensityCode,
 )
 from .const import FILTER_REPLACE_TIME, MAIN_BRUSH_REPLACE_TIME, SENSOR_DIRTY_REPLACE_TIME, SIDE_BRUSH_REPLACE_TIME
 
@@ -240,6 +240,7 @@ class Status(RoborockBase):
     charge_status: Optional[int] = None
     unsave_map_reason: Optional[int] = None
     unsave_map_flag: Optional[int] = None
+
 
 class StatusOldModes(Status):
     water_box_mode: Optional[OldRoborockMopIntensityCode] = None  # type: ignore[valid-type]

--- a/roborock/typing.py
+++ b/roborock/typing.py
@@ -107,6 +107,7 @@ class RoborockCommand(str, Enum):
     GET_DEVICE_ICE = "get_device_ice"
     START_VOICE_CHAT = "start_voice_chat"
     SEND_SDP_TO_ROBOT = "send_sdp_to_robot"
+    GET_FW_FEATURES = "get_fw_features"
 
 
 @dataclass

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,7 +1,6 @@
 from roborock import CleanRecord, CleanSummary, Consumable, DNDTimer, HomeData, Status, StatusOldModes, UserData
 from roborock.code_mappings import (
     OldRoborockFanPowerCode,
-    OldRoborockMopIntensityCode,
     RoborockDockErrorCode,
     RoborockDockTypeCode,
     RoborockErrorCode,
@@ -157,8 +156,6 @@ def test_status():
 
 def test_old_status():
     s = StatusOldModes.from_dict(STATUS)
-    assert isinstance(s.water_box_mode, OldRoborockMopIntensityCode)
-    assert isinstance(s.fan_power, OldRoborockFanPowerCode)
     assert s.msg_ver == 2
     assert s.msg_seq == 458
     assert s.state == RoborockStateCode["8"]

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,12 +1,14 @@
-from roborock import CleanRecord, CleanSummary, Consumable, DNDTimer, HomeData, Status, UserData, StatusOldModes
+from roborock import CleanRecord, CleanSummary, Consumable, DNDTimer, HomeData, Status, StatusOldModes, UserData
 from roborock.code_mappings import (
+    OldRoborockFanPowerCode,
+    OldRoborockMopIntensityCode,
     RoborockDockErrorCode,
     RoborockDockTypeCode,
     RoborockErrorCode,
     RoborockFanPowerCode,
     RoborockMopIntensityCode,
     RoborockMopModeCode,
-    RoborockStateCode, OldRoborockFanPowerCode, OldRoborockMopIntensityCode,
+    RoborockStateCode,
 )
 
 from .mock_data import CLEAN_RECORD, CLEAN_SUMMARY, CONSUMABLE, DND_TIMER, HOME_DATA_RAW, STATUS, USER_DATA
@@ -152,6 +154,7 @@ def test_status():
     assert s.unsave_map_reason == 0
     assert s.unsave_map_flag == 0
 
+
 def test_old_status():
     s = StatusOldModes.from_dict(STATUS)
     assert isinstance(s.water_box_mode, OldRoborockMopIntensityCode)
@@ -160,6 +163,7 @@ def test_old_status():
     assert s.msg_seq == 458
     assert s.state == RoborockStateCode["8"]
     assert s.fan_power == OldRoborockFanPowerCode["102"]
+
 
 def test_dnd_timer():
     dnd = DNDTimer.from_dict(DND_TIMER)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,4 +1,4 @@
-from roborock import CleanRecord, CleanSummary, Consumable, DNDTimer, HomeData, Status, UserData
+from roborock import CleanRecord, CleanSummary, Consumable, DNDTimer, HomeData, Status, UserData, StatusOldModes
 from roborock.code_mappings import (
     RoborockDockErrorCode,
     RoborockDockTypeCode,
@@ -6,7 +6,7 @@ from roborock.code_mappings import (
     RoborockFanPowerCode,
     RoborockMopIntensityCode,
     RoborockMopModeCode,
-    RoborockStateCode,
+    RoborockStateCode, OldRoborockFanPowerCode, OldRoborockMopIntensityCode,
 )
 
 from .mock_data import CLEAN_RECORD, CLEAN_SUMMARY, CONSUMABLE, DND_TIMER, HOME_DATA_RAW, STATUS, USER_DATA
@@ -152,6 +152,14 @@ def test_status():
     assert s.unsave_map_reason == 0
     assert s.unsave_map_flag == 0
 
+def test_old_status():
+    s = StatusOldModes.from_dict(STATUS)
+    assert isinstance(s.water_box_mode, OldRoborockMopIntensityCode)
+    assert isinstance(s.fan_power, OldRoborockFanPowerCode)
+    assert s.msg_ver == 2
+    assert s.msg_seq == 458
+    assert s.state == RoborockStateCode["8"]
+    assert s.fan_power == OldRoborockFanPowerCode["102"]
 
 def test_dnd_timer():
     dnd = DNDTimer.from_dict(DND_TIMER)


### PR DESCRIPTION
Thoughts on this approach?

We can expand it as we find device specific functionality. but the device object is always around so it is easy to access. 

Alternatively we could do an enum but that felt like overkill for right now.