### PR TITLE
fix: remove dnd timer and valley electricity from props

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -323,13 +323,11 @@ class RoborockClient:
     @fallback_cache
     async def get_prop(self) -> DeviceProp | None:
         """Gets device general properties."""
-        [status, clean_summary, consumable, dnd_timer, valley_electricity_timer] = await asyncio.gather(
+        [status, clean_summary, consumable] = await asyncio.gather(
             *[
                 self.get_status(),
                 self.get_clean_summary(),
                 self.get_consumable(),
-                self.get_dnd_timer(),
-                self.get_valley_electricity_timer(),
             ]
         )
         last_clean_record = None
@@ -338,13 +336,11 @@ class RoborockClient:
         dock_summary = None
         if status and status.dock_type is not None and status.dock_type != RoborockDockTypeCode.no_dock:
             dock_summary = await self.get_dock_summary(status.dock_type)
-        if any([status, dnd_timer, clean_summary, consumable]):
+        if any([status, clean_summary, consumable]):
             return DeviceProp(
                 status,
                 clean_summary,
                 consumable,
-                dnd_timer,
-                valley_electricity_timer,
                 last_clean_record,
                 dock_summary,
             )

--- a/roborock/api.py
+++ b/roborock/api.py
@@ -103,6 +103,8 @@ class RoborockClient:
         self._last_disconnection = self.time_func()
         self.keep_alive = KEEPALIVE
         self._diagnostic_data: dict[str, dict[str, Any]] = {}
+        self.dnd_timer: DnDTimer | None = None
+        self.valley_timer: ValleyElectricityTimer | None = None
 
     def __del__(self) -> None:
         self.sync_disconnect()
@@ -255,11 +257,19 @@ class RoborockClient:
 
     @fallback_cache
     async def get_dnd_timer(self) -> DnDTimer | None:
-        return await self.send_command(RoborockCommand.GET_DND_TIMER, return_type=DnDTimer)
+        result = await self.send_command(RoborockCommand.GET_DND_TIMER, return_type=DnDTimer)
+        if result is not None:
+            self.dnd_timer = result
+        return result
 
     @fallback_cache
     async def get_valley_electricity_timer(self) -> ValleyElectricityTimer | None:
-        return await self.send_command(RoborockCommand.GET_VALLEY_ELECTRICITY_TIMER, return_type=ValleyElectricityTimer)
+        result = await self.send_command(
+            RoborockCommand.GET_VALLEY_ELECTRICITY_TIMER, return_type=ValleyElectricityTimer
+        )
+        if result is not None:
+            self.valley_timer = result
+        return result
 
     @fallback_cache
     async def get_clean_summary(self) -> CleanSummary | None:

--- a/roborock/local_api.py
+++ b/roborock/local_api.py
@@ -51,8 +51,6 @@ class RoborockLocalClient(RoborockClient, asyncio.Protocol):
             await self.ping()
         except RoborockException:
             pass
-        if self.keep_alive_task is not None:
-            self.keep_alive_task.cancel()
         self.keep_alive_task = self.loop.call_later(10, lambda: asyncio.create_task(self.keep_alive_func()))
 
     async def async_connect(self) -> None:

--- a/roborock/local_api.py
+++ b/roborock/local_api.py
@@ -51,6 +51,8 @@ class RoborockLocalClient(RoborockClient, asyncio.Protocol):
             await self.ping()
         except RoborockException:
             pass
+        if self.keep_alive_task is not None:
+            self.keep_alive_task.cancel()
         self.keep_alive_task = self.loop.call_later(10, lambda: asyncio.create_task(self.keep_alive_func()))
 
     async def async_connect(self) -> None:

--- a/roborock/roborock_typing.py
+++ b/roborock/roborock_typing.py
@@ -314,8 +314,6 @@ class DeviceProp(RoborockBase):
     status: Optional[Status] = None
     clean_summary: Optional[CleanSummary] = None
     consumable: Optional[Consumable] = None
-    dnd_timer: Optional[DnDTimer] = None
-    valley_electricity_timer: Optional[ValleyElectricityTimer] = None
     last_clean_record: Optional[CleanRecord] = None
     dock_summary: Optional[DockSummary] = None
 
@@ -326,10 +324,6 @@ class DeviceProp(RoborockBase):
             self.clean_summary = device_prop.clean_summary
         if device_prop.consumable:
             self.consumable = device_prop.consumable
-        if device_prop.dnd_timer:
-            self.dnd_timer = device_prop.dnd_timer
-        if device_prop.valley_electricity_timer:
-            self.valley_electricity_timer = device_prop.valley_electricity_timer
         if device_prop.last_clean_record:
             self.last_clean_record = device_prop.last_clean_record
         if device_prop.dock_summary:

--- a/roborock/roborock_typing.py
+++ b/roborock/roborock_typing.py
@@ -8,12 +8,10 @@ from .containers import (
     CleanRecord,
     CleanSummary,
     Consumable,
-    DnDTimer,
     DustCollectionMode,
     RoborockBase,
     SmartWashParams,
     Status,
-    ValleyElectricityTimer,
     WashTowelMode,
 )
 


### PR DESCRIPTION

Ok figured it out, the issue is with 24.0 of python-roborock.

Something with the valley timer and dnd timer being in the get_props.

Which in my opinion, we shouldn't be doing. If you look at how I do it in core, for entities outside of status, I have non-coordinated entities, these entities make the api call directly, that way if they aren't supported or if the user disables that entity, that call wont get made. Or If I update that entity, i.e. a switch on, I can just request the new status of that entity, rather than doing an entire coordinator refresh.

The issue stems with the valley timer, not sure why but that is causing all of the issues.

But for now I'm removing these from props as long as that is fine with you. And if I have time, I will try to rework the switches on homeassistant-roborock to match core as long as this is okay with you