### PR TITLE
feat: adding status and consumable listeners

### DIFF
--- a/roborock/command_cache.py
+++ b/roborock/command_cache.py
@@ -11,6 +11,8 @@ SET_PREFIX = ("set_", "change_", "close_")
 
 
 class CacheableAttribute(str, Enum):
+    status = "status"
+    consumable = "consumable"
     sound_volume = "sound_volume"
     camera_status = "camera_status"
     carpet_clean_mode = "carpet_clean_mode"
@@ -36,12 +38,20 @@ class CacheableAttribute(str, Enum):
 class RoborockAttribute:
     attribute: str
     get_command: RoborockCommand
-    set_command: RoborockCommand
+    set_command: Optional[RoborockCommand] = None
     close_command: Optional[RoborockCommand] = None
 
 
 def create_cache_map():
     cache_map: Mapping[CacheableAttribute, RoborockAttribute] = {
+        CacheableAttribute.status: RoborockAttribute(
+            attribute="status",
+            get_command=RoborockCommand.GET_STATUS,
+        ),
+        CacheableAttribute.consumable: RoborockAttribute(
+            attribute="consumable",
+            get_command=RoborockCommand.GET_CONSUMABLE,
+        ),
         CacheableAttribute.sound_volume: RoborockAttribute(
             attribute="sound_volume",
             get_command=RoborockCommand.GET_SOUND_VOLUME,

--- a/roborock/roborock_message.py
+++ b/roborock/roborock_message.py
@@ -28,15 +28,31 @@ class RoborockDataProtocol(RoborockEnum):
     BATTERY = 122
     FAN_POWER = 123
     WATER_BOX_MODE = 124
-    MAIN_BRUSH_LIFE = 125
-    SIDE_BRUSH_LIFE = 126
-    FILTER_LIFE = 127
+    MAIN_BRUSH_WORK_TIME = 125
+    SIDE_BRUSH_WORK_TIME = 126
+    FILTER_WORK_TIME = 127
     ADDITIONAL_PROPS = 128
     TASK_COMPLETE = 130
     TASK_CANCEL_LOW_POWER = 131
     TASK_CANCEL_IN_MOTION = 132
     CHARGE_STATUS = 133
     DRYING_STATUS = 134
+
+
+ROBOROCK_DATA_STATUS_PROTOCOL = [
+    RoborockDataProtocol.ERROR_CODE,
+    RoborockDataProtocol.STATE,
+    RoborockDataProtocol.BATTERY,
+    RoborockDataProtocol.FAN_POWER,
+    RoborockDataProtocol.WATER_BOX_MODE,
+    RoborockDataProtocol.CHARGE_STATUS,
+]
+
+ROBOROCK_DATA_CONSUMABLE_PROTOCOL = [
+    RoborockDataProtocol.MAIN_BRUSH_WORK_TIME,
+    RoborockDataProtocol.SIDE_BRUSH_WORK_TIME,
+    RoborockDataProtocol.FILTER_WORK_TIME,
+]
 
 
 @dataclass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,8 +77,8 @@ async def test_get_dust_collection_mode():
     home_data = HomeData.from_dict(HOME_DATA_RAW)
     device_info = DeviceData(device=home_data.devices[0], model=home_data.products[0].model)
     rmc = RoborockMqttClient(UserData.from_dict(USER_DATA), device_info)
-    with patch("roborock.cloud_api.RoborockMqttClient.send_command") as command:
-        command.return_value = DustCollectionMode.from_dict({"mode": 1})
+    with patch("roborock.api.AttributeCache.async_value") as command:
+        command.return_value = {"mode": 1}
         dust = await rmc.get_dust_collection_mode()
         assert dust is not None
         assert dust.mode == RoborockDockDustCollectionModeCode.light
@@ -89,8 +89,8 @@ async def test_get_mop_wash_mode():
     home_data = HomeData.from_dict(HOME_DATA_RAW)
     device_info = DeviceData(device=home_data.devices[0], model=home_data.products[0].model)
     rmc = RoborockMqttClient(UserData.from_dict(USER_DATA), device_info)
-    with patch("roborock.cloud_api.RoborockMqttClient.send_command") as command:
-        command.return_value = SmartWashParams.from_dict({"smart_wash": 0, "wash_interval": 1500})
+    with patch("roborock.api.AttributeCache.async_value") as command:
+        command.return_value = {"smart_wash": 0, "wash_interval": 1500}
         mop_wash = await rmc.get_smart_wash_params()
         assert mop_wash is not None
         assert mop_wash.smart_wash == 0
@@ -102,8 +102,8 @@ async def test_get_washing_mode():
     home_data = HomeData.from_dict(HOME_DATA_RAW)
     device_info = DeviceData(device=home_data.devices[0], model=home_data.products[0].model)
     rmc = RoborockMqttClient(UserData.from_dict(USER_DATA), device_info)
-    with patch("roborock.cloud_api.RoborockMqttClient.send_command") as command:
-        command.return_value = WashTowelMode.from_dict({"wash_mode": 2})
+    with patch("roborock.api.AttributeCache.async_value") as command:
+        command.return_value = {"wash_mode": 2}
         washing_mode = await rmc.get_wash_towel_mode()
         assert washing_mode is not None
         assert washing_mode.wash_mode == RoborockDockWashTowelModeCode.deep
@@ -116,7 +116,9 @@ async def test_get_prop():
     device_info = DeviceData(device=home_data.devices[0], model=home_data.products[0].model)
     rmc = RoborockMqttClient(UserData.from_dict(USER_DATA), device_info)
     with patch("roborock.cloud_api.RoborockMqttClient.get_status") as get_status, patch(
-        "roborock.cloud_api.RoborockMqttClient.send_command"
+        "roborock.api.RoborockClient.send_command"
+    ), patch(
+        "roborock.api.AttributeCache.async_value"
     ), patch("roborock.cloud_api.RoborockMqttClient.get_dust_collection_mode"):
         status = S7MaxVStatus.from_dict(STATUS)
         status.dock_type = RoborockDockTypeCode.auto_empty_dock_pure

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ from roborock import (
 )
 from roborock.api import PreparedRequest, RoborockApiClient
 from roborock.cloud_api import RoborockMqttClient
-from roborock.containers import DeviceData, DustCollectionMode, S7MaxVStatus, SmartWashParams, WashTowelMode
+from roborock.containers import DeviceData, S7MaxVStatus
 from tests.mock_data import BASE_URL_REQUEST, GET_CODE_RESPONSE, HOME_DATA_RAW, STATUS, USER_DATA
 
 
@@ -117,9 +117,9 @@ async def test_get_prop():
     rmc = RoborockMqttClient(UserData.from_dict(USER_DATA), device_info)
     with patch("roborock.cloud_api.RoborockMqttClient.get_status") as get_status, patch(
         "roborock.api.RoborockClient.send_command"
-    ), patch(
-        "roborock.api.AttributeCache.async_value"
-    ), patch("roborock.cloud_api.RoborockMqttClient.get_dust_collection_mode"):
+    ), patch("roborock.api.AttributeCache.async_value"), patch(
+        "roborock.cloud_api.RoborockMqttClient.get_dust_collection_mode"
+    ):
         status = S7MaxVStatus.from_dict(STATUS)
         status.dock_type = RoborockDockTypeCode.auto_empty_dock_pure
         get_status.return_value = status


### PR DESCRIPTION
The mqtt client have messages for some attribute changes that are instantly. I'm creating some use for it here