### PR TITLE
fix: downgrade construct

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pycryptodome = "^3.18"
 pycryptodomex = {version = "^3.18", markers = "sys_platform == 'darwin'"}
 paho-mqtt = "^1.6.1"
 dacite = "^1.8.0"
-construct = "^2.10.68"
+construct = "^2.10.56"
 alexapy = "^1.26.8"
 
 


### PR DESCRIPTION
Currently, there is a lock for construct in HA core based off of some other integrations, I'm working on removing it, but for now for test to pass I need to go back to the older version of construct

It may take some time as I need to get my PRs approved for other peoples integrations