### PR TITLE
fix: resolve unawaited task errors on connect/disconnect

### DIFF
--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -5,8 +5,8 @@ import base64
 import logging
 import threading
 import uuid
-from asyncio import Lock
-from typing import Optional
+from asyncio import Lock, Task
+from typing import Any, Optional
 from urllib.parse import urlparse
 
 import paho.mqtt.client as mqtt
@@ -112,40 +112,51 @@ class RoborockMqttClient(RoborockClient, mqtt.Client):
             self._logger.info("Starting mqtt loop")
             super().loop_start()
 
-    def sync_disconnect(self) -> bool:
-        rc = mqtt.MQTT_ERR_AGAIN
-        if self.is_connected():
-            self._logger.info("Disconnecting from mqtt")
-            rc = super().disconnect()
-            if rc not in [mqtt.MQTT_ERR_SUCCESS, mqtt.MQTT_ERR_NO_CONN]:
-                raise RoborockException(f"Failed to disconnect ({mqtt.error_string(rc)})")
-        return rc == mqtt.MQTT_ERR_SUCCESS
+    def sync_disconnect(self) -> tuple[bool, Task[tuple[Any, VacuumError|None]] | None]:
+        if not self.is_connected():
+            return False, None
 
-    def sync_connect(self) -> bool:
-        should_connect = not self.is_connected()
-        if should_connect:
-            if self._mqtt_port is None or self._mqtt_host is None:
-                raise RoborockException("Mqtt information was not entered. Cannot connect.")
-            self._logger.info("Connecting to mqtt")
-            super().connect(host=self._mqtt_host, port=self._mqtt_port, keepalive=KEEPALIVE)
+        self._logger.info("Disconnecting from mqtt")
+        disconnected_future = asyncio.ensure_future(self._async_response(DISCONNECT_REQUEST_ID))
+        rc = super().disconnect()
+
+        if rc != mqtt.MQTT_ERR_SUCCESS:
+            disconnected_future.cancel()
+            disconnected_future = None
+
+        if rc not in [mqtt.MQTT_ERR_SUCCESS, mqtt.MQTT_ERR_NO_CONN]:
+            raise RoborockException(f"Failed to disconnect ({mqtt.error_string(rc)})")
+
+        return rc == mqtt.MQTT_ERR_SUCCESS, disconnected_future
+
+    def sync_connect(self) -> tuple[bool, Task[tuple[Any, VacuumError|None]] | None]:
+        if self.is_connected():
+            self.sync_start_loop()
+            return False, None
+
+        if self._mqtt_port is None or self._mqtt_host is None:
+            raise RoborockException("Mqtt information was not entered. Cannot connect.")
+
+        self._logger.info("Connecting to mqtt")
+        connected_future = asyncio.ensure_future(self._async_response(CONNECT_REQUEST_ID))
+        super().connect(host=self._mqtt_host, port=self._mqtt_port, keepalive=KEEPALIVE)
+
         self.sync_start_loop()
-        return should_connect
+        return True, connected_future
 
     async def async_disconnect(self) -> None:
         async with self._mutex:
-            async_response = asyncio.ensure_future(self._async_response(DISCONNECT_REQUEST_ID))
-            disconnecting = self.sync_disconnect()
+            (disconnecting, disconnected_future) = self.sync_disconnect()
             if disconnecting:
-                (_, err) = await async_response
+                (_, err) = await disconnected_future
                 if err:
                     raise RoborockException(err) from err
 
     async def async_connect(self) -> None:
         async with self._mutex:
-            async_response = asyncio.ensure_future(self._async_response(CONNECT_REQUEST_ID))
-            connecting = self.sync_connect()
+            (connecting, connected_future) = self.sync_connect()
             if connecting:
-                (_, err) = await async_response
+                (_, err) = await connected_future
                 if err:
                     raise RoborockException(err) from err
 


### PR DESCRIPTION
The mqtt client now logs exceptions like `Error doing job: Task exception was never retrieved [...] RoborockTimeout: id=0 Timeout after 4 seconds` when it's already connected.

This PR fixes that by only calling `_async_response` when we actually need to connect. (Including the same-ish fix for disconnect.)

Full log entry:
```
2023-08-05 13:32:15.078 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved:   File "/home/vscode/.local/bin/hass", line 8, in <module>
    sys.exit(main())
  File "/home/vscode/.local/lib/python3.11/site-packages/homeassistant/__main__.py", line 214, in main
    exit_code = runner.run(runtime_conf)
  File "/home/vscode/.local/lib/python3.11/site-packages/homeassistant/runner.py", line 179, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 640, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 607, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 1914, in _run_once
    handle._run()
  File "/usr/local/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/workspaces/homeassistant-roborock/roborock/api.py", line 428, in get_consumable
    return Consumable.from_dict(await self.cache[CacheableAttribute.consumable].async_value())
  File "/workspaces/homeassistant-roborock/roborock/api.py", line 128, in async_value
    return await self.task.reset()
  File "/workspaces/homeassistant-roborock/roborock/util.py", line 101, in reset
    return await self._run_task()
  File "/workspaces/homeassistant-roborock/roborock/util.py", line 86, in _run_task
    response = await self.callback()
  File "/workspaces/homeassistant-roborock/roborock/api.py", line 122, in _async_value
    self._value = await self.api._send_command(self.attribute.get_command)
  File "/workspaces/homeassistant-roborock/roborock/cloud_api.py", line 195, in _send_command
    return await self.send_message(roborock_message)
  File "/workspaces/homeassistant-roborock/roborock/cloud_api.py", line 158, in send_message
    await self.validate_connection()
  File "/workspaces/homeassistant-roborock/roborock/api.py", line 312, in validate_connection
    await self.async_connect()
  File "/workspaces/homeassistant-roborock/roborock/cloud_api.py", line 145, in async_connect
    async_response = asyncio.ensure_future(self._async_response(CONNECT_REQUEST_ID))
  File "/usr/local/lib/python3.11/asyncio/tasks.py", line 649, in ensure_future
    return _ensure_future(coro_or_future, loop=loop)
  File "/usr/local/lib/python3.11/asyncio/tasks.py", line 670, in _ensure_future
    return loop.create_task(coro_or_future)
Traceback (most recent call last):
  File "/workspaces/homeassistant-roborock/roborock/api.py", line 321, in _wait_response
    raise RoborockTimeout(f"id={request_id} Timeout after {QUEUE_TIMEOUT} seconds") from None
roborock.exceptions.RoborockTimeout: id=0 Timeout after 4 seconds
```