### PR TITLE
fix: status reworking

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -185,6 +185,7 @@ class RoborockClient:
             device_cache[device_info.device.duid] = cache
         self.cache: dict[CacheableAttribute, AttributeCache] = cache
         self._listeners: list[Callable[[str, CacheableAttribute, RoborockBase], None]] = []
+        self.is_available: bool = False
 
     def __del__(self) -> None:
         self.release()

--- a/roborock/api.py
+++ b/roborock/api.py
@@ -186,9 +186,7 @@ class RoborockClient:
         self._listeners: list[Callable[[str, CacheableAttribute, RoborockBase], None]] = []
         self.is_available: bool = True
         self.queue_timeout = queue_timeout
-        self._status_type: type[Status] = ModelStatus.get(
-                                        self.device_info.model, S7MaxVStatus
-                                    )
+        self._status_type: type[Status] = ModelStatus.get(self.device_info.model, S7MaxVStatus)
 
     def __del__(self) -> None:
         self.release()
@@ -265,7 +263,7 @@ class RoborockClient:
                                         self._logger.debug(
                                             f"Got status update({data_protocol.name}) before get_status was called."
                                         )
-                                        self.cache[CacheableAttribute.status]._value = {}
+                                        return
                                     value = self.cache[CacheableAttribute.status].value
                                     value[data_protocol.name] = data_point
                                     status = self._status_type.from_dict(value)
@@ -277,7 +275,7 @@ class RoborockClient:
                                             f"Got consumable update({data_protocol.name})"
                                             + "before get_consumable was called."
                                         )
-                                        self.cache[CacheableAttribute.consumable]._value = {}
+                                        return
                                     value = self.cache[CacheableAttribute.consumable].value
                                     value[data_protocol.name] = data_point
                                     consumable = Consumable.from_dict(value)

--- a/roborock/api.py
+++ b/roborock/api.py
@@ -184,7 +184,7 @@ class RoborockClient:
             device_cache[device_info.device.duid] = cache
         self.cache: dict[CacheableAttribute, AttributeCache] = cache
         self._listeners: list[Callable[[str, CacheableAttribute, RoborockBase], None]] = []
-        self.is_available: bool = False
+        self.is_available: bool = True
         self.queue_timeout = queue_timeout
 
     def __del__(self) -> None:

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -138,7 +138,7 @@ class RoborockMqttClient(RoborockClient, mqtt.Client):
         if self._mqtt_port is None or self._mqtt_host is None:
             raise RoborockException("Mqtt information was not entered. Cannot connect.")
 
-        self._logger.info("Connecting to mqtt")
+        self._logger.debug("Connecting to mqtt")
         connected_future = asyncio.ensure_future(self._async_response(CONNECT_REQUEST_ID))
         super().connect(host=self._mqtt_host, port=self._mqtt_port, keepalive=KEEPALIVE)
 

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -29,12 +29,12 @@ class RoborockMqttClient(RoborockClient, mqtt.Client):
     _thread: threading.Thread
     _client_id: str
 
-    def __init__(self, user_data: UserData, device_info: DeviceData) -> None:
+    def __init__(self, user_data: UserData, device_info: DeviceData, queue_timeout: int = 10) -> None:
         rriot = user_data.rriot
         if rriot is None:
             raise RoborockException("Got no rriot data from user_data")
         endpoint = base64.b64encode(Utils.md5(rriot.k.encode())[8:14]).decode()
-        RoborockClient.__init__(self, endpoint, device_info)
+        RoborockClient.__init__(self, endpoint, device_info, queue_timeout)
         mqtt.Client.__init__(self, protocol=mqtt.MQTTv5)
         self._logger = RoborockLoggerAdapter(device_info.device.name, _LOGGER)
         self._mqtt_user = rriot.u

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -408,7 +408,9 @@ class CleanSummary(RoborockBase):
 @dataclass
 class CleanRecord(RoborockBase):
     begin: Optional[int] = None
+    begin_datetime: datetime.datetime | None = None
     end: Optional[int] = None
+    end_datetime: datetime.datetime | None = None
     duration: Optional[int] = None
     area: Optional[int] = None
     square_meter_area: Optional[float] = None
@@ -424,6 +426,8 @@ class CleanRecord(RoborockBase):
 
     def __post_init__(self) -> None:
         self.square_meter_area = round(self.area / 1000000, 1) if self.area is not None else None
+        self.begin_datetime = datetime.datetime.fromtimestamp(self.begin).astimezone(datetime.UTC) if self.begin else None
+        self.end_datetime = datetime.datetime.fromtimestamp(self.end).astimezone(datetime.UTC) if self.end else None
 
 
 @dataclass

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -426,7 +426,9 @@ class CleanRecord(RoborockBase):
 
     def __post_init__(self) -> None:
         self.square_meter_area = round(self.area / 1000000, 1) if self.area is not None else None
-        self.begin_datetime = datetime.datetime.fromtimestamp(self.begin).astimezone(datetime.UTC) if self.begin else None
+        self.begin_datetime = (
+            datetime.datetime.fromtimestamp(self.begin).astimezone(datetime.UTC) if self.begin else None
+        )
         self.end_datetime = datetime.datetime.fromtimestamp(self.end).astimezone(datetime.UTC) if self.end else None
 
 

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -407,9 +407,9 @@ class CleanSummary(RoborockBase):
 
 @dataclass
 class CleanRecord(RoborockBase):
-    begin: Optional[int] = None
+    begin: int | None = None
     begin_datetime: datetime.datetime | None = None
-    end: Optional[int] = None
+    end: int | None = None
     end_datetime: datetime.datetime | None = None
     duration: int | None = None
     area: int | None = None

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -4,9 +4,10 @@ import datetime
 import logging
 import re
 from dataclasses import asdict, dataclass
+from datetime import timezone
 from enum import Enum
 from typing import Any, NamedTuple
-from datetime import timezone
+
 from dacite import Config, from_dict
 
 from .code_mappings import (

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, NamedTuple
-
+from datetime import timezone
 from dacite import Config, from_dict
 
 from .code_mappings import (
@@ -427,9 +427,9 @@ class CleanRecord(RoborockBase):
     def __post_init__(self) -> None:
         self.square_meter_area = round(self.area / 1000000, 1) if self.area is not None else None
         self.begin_datetime = (
-            datetime.datetime.fromtimestamp(self.begin).astimezone(datetime.UTC) if self.begin else None
+            datetime.datetime.fromtimestamp(self.begin).astimezone(timezone.utc) if self.begin else None
         )
-        self.end_datetime = datetime.datetime.fromtimestamp(self.end).astimezone(datetime.UTC) if self.end else None
+        self.end_datetime = datetime.datetime.fromtimestamp(self.end).astimezone(timezone.utc) if self.end else None
 
 
 @dataclass

--- a/roborock/local_api.py
+++ b/roborock/local_api.py
@@ -59,7 +59,7 @@ class RoborockLocalClient(RoborockClient, asyncio.Protocol):
                 if not self.is_connected():
                     self.sync_disconnect()
                     async with async_timeout.timeout(self.queue_timeout):
-                        self._logger.info(f"Connecting to {self.host}")
+                        self._logger.debug(f"Connecting to {self.host}")
                         self.transport, _ = await self.event_loop.create_connection(  # type: ignore
                             lambda: self, self.host, 58867
                         )

--- a/roborock/local_api.py
+++ b/roborock/local_api.py
@@ -7,7 +7,7 @@ from asyncio import Lock, TimerHandle, Transport
 import async_timeout
 
 from . import DeviceData
-from .api import COMMANDS_SECURED, QUEUE_TIMEOUT, RoborockClient
+from .api import COMMANDS_SECURED, RoborockClient
 from .exceptions import CommandVacuumError, RoborockConnectionException, RoborockException
 from .protocol import MessageParser
 from .roborock_message import MessageRetry, RoborockMessage, RoborockMessageProtocol
@@ -58,7 +58,7 @@ class RoborockLocalClient(RoborockClient, asyncio.Protocol):
             try:
                 if not self.is_connected():
                     self.sync_disconnect()
-                    async with async_timeout.timeout(QUEUE_TIMEOUT):
+                    async with async_timeout.timeout(self.queue_timeout):
                         self._logger.info(f"Connecting to {self.host}")
                         self.transport, _ = await self.event_loop.create_connection(  # type: ignore
                             lambda: self, self.host, 58867

--- a/roborock/local_api.py
+++ b/roborock/local_api.py
@@ -18,10 +18,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class RoborockLocalClient(RoborockClient, asyncio.Protocol):
-    def __init__(self, device_data: DeviceData):
+    def __init__(self, device_data: DeviceData, queue_timeout: int = 4):
         if device_data.host is None:
             raise RoborockException("Host is required")
-        super().__init__("abc", device_data)
+        super().__init__("abc", device_data, queue_timeout)
         self.host = device_data.host
         self._batch_structs: list[RoborockMessage] = []
         self._executing = False


### PR DESCRIPTION
Instead of getting status each time we need it, we get it once so it is always available.

As well, we Shouldn't set the cache based off of listener if nothing exist, this was causing a few issues when I was testing robustness of being able to set up in core when the device is offline and then comes online