### PR TITLE
fix: Add S5Max Mop Code 207

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -246,6 +246,7 @@ class RoborockMopIntensityS5Max(RoborockMopIntensityCode):
     medium = 202
     high = 203
     custom = 204
+    custom_water_flow = 207
 
 
 class RoborockDockErrorCode(RoborockEnum):


### PR DESCRIPTION
Add Mop Code 207 to eliminate error:

```
Logger: roborock.code_mappings
Source: runner.py:186
First occurred: 5:41:40 PM (1 occurrences)
Last logged: 5:41:40 PM

Missing RoborockMopIntensityS5Max code: 207 - defaulting to 200
```