### PR TITLE
fix: error catch and typing

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -293,7 +293,10 @@ class RoborockClient:
                     payload = data.payload[0:24]
                     [endpoint, _, request_id, _] = struct.unpack("<8s8sH6s", payload)
                     if endpoint.decode().startswith(self._endpoint):
-                        decrypted = Utils.decrypt_cbc(data.payload[24:], self._nonce)
+                        try:
+                            decrypted = Utils.decrypt_cbc(data.payload[24:], self._nonce)
+                        except ValueError as err:
+                            raise RoborockException("Failed to decode %s for %s", data.payload, data.protocol) from err
                         decompressed = Utils.decompress(decrypted)
                         queue = self._waiting_queue.get(request_id)
                         if queue:


### PR DESCRIPTION
mypy yells about not having a py.typed file that mars our repository as a typed repository. 

Also sometimes padding fails, and I don't know why, so I am adding a exception to better help diagnose.