### PR TITLE
Added: Roborock G10 Variant- roborock.vacuum.a30

### DIFF
--- a/roborock/const.py
+++ b/roborock/const.py
@@ -26,6 +26,7 @@ ROBOROCK_Q7PLUS = "roborock.vacuum.a40"
 ROBOROCK_G10S_PRO = "roborock.vacuum.a26"
 ROBOROCK_G10S = "roborock.vacuum.a46"
 ROBOROCK_G10 = "roborock.vacuum.a29"
+ROCKROBO_G10_SG = "roborock.vacuum.a30" # Variant of the G10, has similar features as S7
 ROBOROCK_S7 = "roborock.vacuum.a15"
 ROBOROCK_S6_MAXV = "roborock.vacuum.a10"
 ROBOROCK_E2 = "roborock.vacuum.e2"
@@ -53,5 +54,6 @@ SUPPORTED_VACUUMS = (
         ROBOROCK_S4_MAX,
         ROBOROCK_S7,
         ROBOROCK_P10,
+        ROCKROBO_G10_SG,
     ]
 )


### PR DESCRIPTION
Related PR: https://github.com/humbertogontijo/homeassistant-roborock/pull/536

https://home.miot-spec.com/spec/roborock.vacuum.a30

<details>
<summary>Miiot details</summary>

```json
{
      "did": <redacted>,
      "uid": <redacted>,
      "token": <redacted>,
      "name": "Roborock G10",
      "pid": 0,
      "localip": <redacted>,
      "mac": <redacted>,
      "ssid": <redacted>,
      "bssid": <redacted>,
      "rssi": -37,
      "longitude": "0.00000000",
      "latitude": "0.00000000",
      "show_mode": 1,
      "model": "roborock.vacuum.a30",
      "permitLevel": 16,
      "isOnline": false,
      "spec_type": "urn:miot-spec-v2:device:vacuum:0000A006:roborock-a30:1",
      "extra": {
        "isSetPincode": 0,
        "pincodeType": 0,
        "fw_version": "4.3.5_1292",
        "isSubGroup": false,
        "showGroupMember": false,
        "split": {}
      },
      "orderTime": 1672797489,
      "freqFlag": true,
      "hide_mode": 0,
      "last_online": 1698738321,
      "comFlag": 129
}
```

</details>