### PR TITLE
fix: add information from product api

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -65,8 +65,21 @@ class RoborockStateCode(RoborockEnum):
     emptying_the_bin = 22  # on s7+
     washing_the_mop = 23  # on a46
     going_to_wash_the_mop = 26  # on a46
+    in_call = 28
+    mapping = 29
     charging_complete = 100
     device_offline = 101
+
+
+class RoborockDyadStateCode(RoborockEnum):
+    washing = 1
+    ready = 2
+    charging = 3
+    mop_washing = 4
+    drying = 10
+    reserving = 12
+    mop_washing_paused = 13
+    dusting_mode = 14
 
 
 class RoborockErrorCode(RoborockEnum):

--- a/roborock/const.py
+++ b/roborock/const.py
@@ -18,11 +18,14 @@ ROBOROCK_T7 = "roborock.vacuum.a11"  # cn s7
 ROBOROCK_T7S = "roborock.vacuum.a14"
 ROBOROCK_T7SPLUS = "roborock.vacuum.a23"
 ROBOROCK_S7_MAXV = "roborock.vacuum.a27"
+ROBOROCK_S7_MAXV_ULTRA = "roborock.vacuum.a65"
 ROBOROCK_S7_PRO_ULTRA = "roborock.vacuum.a62"
 ROBOROCK_Q5 = "roborock.vacuum.a34"
-ROBOROCK_Q7 = "roborock.vacuum.a37"  # CHECK THIS
+ROBOROCK_Q5_PRO = "roborock.vacuum.a72"
+ROBOROCK_Q7 = "roborock.vacuum.a40"
 ROBOROCK_Q7_MAX = "roborock.vacuum.a38"
 ROBOROCK_Q7PLUS = "roborock.vacuum.a40"
+ROBOROCK_Q8_MAX = "roborock.vacuum.a73"
 ROBOROCK_G10S_PRO = "roborock.vacuum.a26"
 ROBOROCK_G10S = "roborock.vacuum.a46"
 ROBOROCK_G10 = "roborock.vacuum.a29"
@@ -35,6 +38,10 @@ ROBOROCK_C1 = "roborock.vacuum.c1"
 ROBOROCK_S8_PRO_ULTRA = "roborock.vacuum.a70"
 ROBOROCK_S8 = "roborock.vacuum.a51"
 ROBOROCK_P10 = "roborock.vacuum.a75"
+
+ROBOROCK_DYAD_AIR = "roborock.wetdryvac.a107"
+ROBOROCK_DYAD_PRO_COMBO = "roborock.wetdryvac.a83"
+ROBOROCK_DYAD_PRO = "roborock.wetdryvac.a56"
 
 SUPPORTED_VACUUMS = (
     [  # These are the devices that show up when you add a device - more could be supported and just not show up

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 import re
 from dataclasses import asdict, dataclass, field
@@ -589,3 +590,79 @@ class ServerTimer(NamedTuple):
     id: str
     status: str
     dontknow: int
+
+
+@dataclass
+class RoborockProductStateValue(RoborockBase):
+    value: list
+    desc: dict
+
+
+@dataclass
+class RoborockProductState(RoborockBase):
+    dps: int
+    desc: dict
+    value: list[RoborockProductStateValue]
+
+
+@dataclass
+class RoborockProductSpec(RoborockBase):
+    state: RoborockProductState
+    battery: dict | None = None
+    dry_countdown: dict | None = None
+    extra: dict | None = None
+    offpeak: dict | None = None
+    countdown: dict | None = None
+    mode: dict | None = None
+    ota_nfo: dict | None = None
+    pause: dict | None = None
+    program: dict | None = None
+    shutdown: dict | None = None
+    washing_left: dict | None = None
+
+
+@dataclass
+class RoborockProduct(RoborockBase):
+    id: int
+    name: str
+    model: str
+    packagename: str
+    ssid: str
+    picurl: str
+    cardpicurl: str
+    medium_cardpicurl: str
+    resetwifipicurl: str
+    resetwifitext: dict
+    tuyaid: str
+    status: int
+    rriotid: str
+    cardspec: str
+    pictures: list
+    nc_mode: str
+    scope: None
+    product_tags: list
+    agreements: list
+    plugin_pic_url: None
+    products_specification: RoborockProductSpec | None = None
+
+    def __post_init__(self):
+        if self.cardspec:
+            self.products_specification = RoborockProductSpec.from_dict(json.loads(self.cardspec).get("data"))
+
+
+@dataclass
+class RoborockProductCategory(RoborockBase):
+    id: int
+    display_name: str
+    icon_url: str
+
+
+@dataclass
+class RoborockCategoryDetail(RoborockBase):
+    category: RoborockProductCategory
+    product_list: list[RoborockProduct]
+
+
+@dataclass
+class ProductResponse(RoborockBase):
+    category_detail_list: list[RoborockCategoryDetail]

--- a/roborock/roborock_message.py
+++ b/roborock/roborock_message.py
@@ -42,6 +42,51 @@ class RoborockDataProtocol(RoborockEnum):
         raise ValueError("%s not a valid key for Data Protocol", key)
 
 
+class RoborockDyadDataProtocol(RoborockEnum):
+    DRYING_STATUS = 134
+    START = 200
+    STATUS = 201
+    SELF_CLEAN_MODE = 202
+    SELF_CLEAN_LEVEL = 203
+    WARM_LEVEL = 204
+    CLEAN_MODE = 205
+    SUCTION = 206
+    WATER_LEVEL = 207
+    BRUSH_SPEED = 208
+    POWER = 209
+    COUNTDOWN_TIME = 210
+    AUTO_SELF_CLEAN_SET = 212
+    AUTO_DRY = 213
+    MESH_LEF = 214
+    BRUSH_LEFT = 215
+    ERROR = 216
+    MESH_RESET = 218
+    BRUSH_RESET = 219
+    VOLUME_SET = 221
+    STAND_LOCK_AUTO_RUN = 222
+    AUTO_SELF_CLEAN_SET_MODE = 223
+    AUTO_DRY_MODE = 224
+    SILENT_DRY_DURATION = 225
+    SILENT_MODE = 226
+    SILENT_MODE_START_TIME = 227
+    SILENT_MODE_END_TIME = 228
+    RECENT_RUN_TIMe = 229
+    TOTAL_RUN_TIME = 230
+    FEATURE_INFO = 235
+    RECOVER_SETTINGS = 236
+    DRY_COUNTDOWN = 237
+    ID_QUERY = 10000
+    F_C = 10001
+    SCHEDULE_TASK = 10002
+    SND_SWITCH = 10003
+    SND_STATE = 10004
+    PRODUCT_INFO = 10005
+    PRIVACY_INFO = 10006
+    OTA_NFO = 10007
+    RPC_REQUEST = 10101
+    RPC_RESPONSE = 10102
+
+
 ROBOROCK_DATA_STATUS_PROTOCOL = [
     RoborockDataProtocol.ERROR_CODE,
     RoborockDataProtocol.STATE,


### PR DESCRIPTION
The product api had some good information including new status codes, some status codes for the dyad series, model numbers, etc. 