### PR TITLE
fix: set roommapping when it is only one room

### DIFF
--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -277,7 +277,7 @@ class RoborockClientV1(RoborockClient):
         """Gets the mapping from segment id -> iot id. Only works on local api."""
         mapping: list = await self.send_command(RoborockCommand.GET_ROOM_MAPPING)
         if isinstance(mapping, list):
-            if not isinstance(mapping[0], list):
+            if not isinstance(mapping[0], list) and len(mapping) == 2:
                 return [RoomMapping(segment_id=mapping[0], iot_id=mapping[1])]
             return [
                 RoomMapping(segment_id=segment_id, iot_id=iot_id)  # type: ignore


### PR DESCRIPTION
There is a bug where if only one room is on a map, it only sends a 1d array instead of a 2d array, and our code fails.