### PR TITLE
fix: add missing value "high = 203" to RoborockMopIntensityS8MaxVUltra

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -323,6 +323,7 @@ class RoborockMopIntensityS8MaxVUltra(RoborockMopIntensityCode):
     off = 200
     low = 201
     medium = 202
+    high = 203
     smart_mode = 209
     custom_water_flow = 207
 


### PR DESCRIPTION
Solves the warning 

```Missing RoborockMopIntensityS8MaxVUltra code: 203 - defaulting to 200```

if command "get_status" is sent with return_type=S8MaxvUltraStatus