### PR TITLE
fix: handle weird clean record response

### DIFF
--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -197,6 +197,8 @@ class RoborockClientV1(RoborockClient):
         if isinstance(record, dict):
             return CleanRecord.from_dict(record)
         elif isinstance(record, list):
+            if isinstance(record[-1], dict):
+                return CleanRecord.from_dict(record[-1])
             # There are still a few unknown variables in this.
             begin, end, duration, area = unpack_list(record, 4)
             return CleanRecord(begin=begin, end=end, duration=duration, area=area)

--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -198,7 +198,23 @@ class RoborockClientV1(RoborockClient):
             return CleanRecord.from_dict(record)
         elif isinstance(record, list):
             if isinstance(record[-1], dict):
-                return CleanRecord.from_dict(record[-1])
+                records = [CleanRecord.from_dict(rec) for rec in record]
+                final_record = records[-1]
+                try:
+                    # This code is semi-presumptions - so it is put in a try finally to be safe.
+                    final_record.begin = records[0].begin
+                    final_record.begin_datetime = records[0].begin_datetime
+                    final_record.start_type = records[0].start_type
+                    for rec in records[0:-1]:
+                        final_record.duration += rec.duration if rec.duration is not None else 0
+                        final_record.area += rec.area if rec.area is not None else 0
+                        final_record.avoid_count += rec.avoid_count if rec.avoid_count is not None else 0
+                        final_record.wash_count += rec.wash_count if rec.wash_count is not None else 0
+                        final_record.square_meter_area += (
+                            rec.square_meter_area if rec.square_meter_area is not None else 0
+                        )
+                finally:
+                    return final_record
             # There are still a few unknown variables in this.
             begin, end, duration, area = unpack_list(record, 4)
             return CleanRecord(begin=begin, end=end, duration=duration, area=area)

--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -295,7 +295,7 @@ class RoborockClientV1(RoborockClient):
         """Gets the mapping from segment id -> iot id. Only works on local api."""
         mapping: list = await self.send_command(RoborockCommand.GET_ROOM_MAPPING)
         if isinstance(mapping, list):
-            if not isinstance(mapping[0], list) and len(mapping) == 2:
+            if len(mapping) == 2 and not isinstance(mapping[0], list):
                 return [RoomMapping(segment_id=mapping[0], iot_id=mapping[1])]
             return [
                 RoomMapping(segment_id=segment_id, iot_id=iot_id)  # type: ignore


### PR DESCRIPTION
Oddly enough - sometimes two records can apparently come back for one timestamp - while that makes no logical sense, this handles it.