### PR TITLE
chore: Update documentation for reset_consumable

### DIFF
--- a/docs/source/api_commands.rst
+++ b/docs/source/api_commands.rst
@@ -992,7 +992,9 @@ reset_consumable
 
 Description:
 
-Parameters:
+Parameters: List of consumables to reset. For example, to reset consumables 'strainer_work_times' and 'sensor_dirty_time' the parameter would be
+
+ ['strainer_work_times', 'sensor_dirty_time']
 
 ======================  =========
 Vacuum Model            Supported


### PR DESCRIPTION
This change adds documentation for the API function `reset_consumable`.

It adds information about the format of parameters for the function.