### PR TITLE
fix: S8 maxv highest mop intensity setting

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -324,6 +324,7 @@ class RoborockMopIntensityS8MaxVUltra(RoborockMopIntensityCode):
     low = 201
     medium = 202
     high = 203
+    max = 208
     smart_mode = 209
     custom_water_flow = 207
 


### PR DESCRIPTION
Newest roborock s8 maxv has one more mop intensity setting. I am open to changing its name

<img width="650" alt="image" src="https://github.com/humbertogontijo/python-roborock/assets/3405384/ab7d898a-47c4-485b-9d80-af042ec852ef">
