### PR TITLE
fix: s8 maxv has a wash and fill dock

### DIFF
--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -65,6 +65,7 @@ WASH_N_FILL_DOCK = [
     RoborockDockTypeCode.empty_wash_fill_dock,
     RoborockDockTypeCode.s8_dock,
     RoborockDockTypeCode.p10_dock,
+    RoborockDockTypeCode.s8_maxv_ultra_dock,
 ]
 RT = TypeVar("RT", bound=RoborockBase)
 EVICT_TIME = 60


### PR DESCRIPTION
I was checking what else is missing for s8 maxv. This model has a dock that washes the mop and also fills the robot. So I think it should be included in this list.

Please let me know if I have to do anything else.