### PR TITLE
S8MaxVUltra is missing some code mappings

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -248,7 +248,10 @@ class RoborockFanSpeedP10(RoborockFanPowerCode):
 
 class RoborockFanSpeedS8MaxVUltra(RoborockFanPowerCode):
     off = 105
+    quiet = 101
     balanced = 102
+    turbo = 103
+    max = 104
     custom = 106
     max_plus = 108
     smart_mode = 110
@@ -324,6 +327,7 @@ class RoborockMopIntensityS8MaxVUltra(RoborockMopIntensityCode):
     low = 201
     medium = 202
     high = 203
+    custom = 204
     max = 208
     smart_mode = 209
     custom_water_flow = 207

--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -395,6 +395,7 @@ class RoborockDockWashTowelModeCode(RoborockEnum):
     light = 0
     balanced = 1
     deep = 2
+    smart = 10
 
 
 class RoborockCategory(Enum):


### PR DESCRIPTION
With current release (i.e adding the dock from https://github.com/humbertogontijo/python-roborock/pull/213) following warn messages appear within home assistant:
```
2024-06-06 10:06:10.775 WARNING (MainThread) [roborock.code_mappings] Missing RoborockDockWashTowelModeCode code: 10 - defaulting to 'unknown'
2024-06-06 10:06:19.505 WARNING (Thread-2 (_thread_main)) [roborock.code_mappings] Missing RoborockFanSpeedS8MaxVUltra code: 101 - defaulting to 105
2024-06-06 10:06:30.545 WARNING (Thread-2 (_thread_main)) [roborock.code_mappings] Missing RoborockFanSpeedS8MaxVUltra code: 103 - defaulting to 105
2024-06-06 10:06:31.922 WARNING (Thread-2 (_thread_main)) [roborock.code_mappings] Missing RoborockFanSpeedS8MaxVUltra code: 104 - defaulting to 105
2024-06-06 10:08:30.442 WARNING (Thread-2 (_thread_main)) [roborock.code_mappings] Missing RoborockMopIntensityS8MaxVUltra code: 204 - defaulting to 200
```

Following PR adds the missing code mappings.

RoborockDockWashTowelModeCode 
![grafik](https://github.com/humbertogontijo/python-roborock/assets/168727804/9a36479d-fec2-42d9-aa46-5f39a0483d11)

RoborockMopIntensityS8MaxVUltra 
![grafik](https://github.com/humbertogontijo/python-roborock/assets/168727804/1cf56561-4111-4279-bca1-07efb0dc315c)

RoborockFanSpeedS8MaxVUltra
![grafik](https://github.com/humbertogontijo/python-roborock/assets/168727804/51ebd665-fb21-4a16-bc6f-1d92fdac090a)
