### PR TITLE
feat: add q revo pro/p10 pro support

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -384,6 +384,7 @@ class RoborockDockTypeCode(RoborockEnum):
     s7_max_ultra_dock = 6
     s8_dock = 7
     p10_dock = 8
+    p10_pro_dock = 9
     s8_maxv_ultra_dock = 10
 
 

--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -65,6 +65,7 @@ WASH_N_FILL_DOCK = [
     RoborockDockTypeCode.empty_wash_fill_dock,
     RoborockDockTypeCode.s8_dock,
     RoborockDockTypeCode.p10_dock,
+    RoborockDockTypeCode.p10_pro_dock,
     RoborockDockTypeCode.s8_maxv_ultra_dock,
 ]
 RT = TypeVar("RT", bound=RoborockBase)


### PR DESCRIPTION
I have a Q Revo Pro / P10 Pro which triggers the following warning:

`Missing RoborockDockTypeCode code: 9 - defaulting to 'unknown'`