### PR TITLE
fix: bump semantic release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
     concurrency: release
     permissions:
       id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/python-roborock/
 
     steps:
     - uses: actions/checkout@v4
@@ -75,7 +78,10 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@v1.12.2
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}
+
       # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
       # See https://github.com/actions/runner/issues/1173
       if: steps.release.outputs.released == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5.4.4
+      - uses: wagoid/commitlint-github-action@v5.4.5
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: pre-commit/action@v3.0.0
 
   test:
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1.3.4
+      - uses: snok/install-poetry@v1.4.1
       - name: Install Dependencies
         run: poetry install
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     needs:
       - test
     concurrency: release
+    if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write
     environment:
@@ -72,7 +73,6 @@ jobs:
 
     - name: Python Semantic Release
       id: release
-      if: github.ref == 'refs/heads/main'
       uses: python-semantic-release/python-semantic-release@v8.7.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,30 +56,32 @@ jobs:
         shell: bash
   release:
     runs-on: ubuntu-latest
-    environment: release
     needs:
       - test
+    concurrency: release
+    permissions:
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      # Run semantic release:
-      # - Update CHANGELOG.md
-      # - Update version in code
-      # - Create git tag
-      # - Create GitHub release
-      # - Publish to PyPI
-      - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v7.34.6
-        if: github.ref == 'refs/heads/main'
-        with:
-          github_token: ${{ secrets.GH_TOKEN }}
-          repository_username: __token__
-          repository_password: ${{ secrets.PYPI_TOKEN }}
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@v7.34.6
-        if: github.ref_name != 'main'
-        with:
-          additional_options: --noop
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Python Semantic Release
+      id: release
+      if: github.ref == 'refs/heads/main'
+      uses: python-semantic-release/python-semantic-release@v8.7.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@v1
+      # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+      # See https://github.com/actions/runner/issues/1173
+      if: steps.release.outputs.released == 'true'
+
+    - name: Publish package distributions to GitHub Releases
+      uses: python-semantic-release/upload-to-gh-release@v8.7.0
+      if: steps.release.outputs.released == 'true'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have no idea if this will work tbh.

But we are so behind on the semantic release versioning it isn't working with the newer python versioning required for the map parser.

I took this config directly from their migration guide.