### PR TITLE
fix: semantic release versioning tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-roborock"
-version = "2.8.0"
+version = "2.8.1"
 description = "A package to control Roborock vacuums."
 authors = ["humbertogontijo <humbertogontijo@users.noreply.github.com>"]
 license = "GPL-3.0-only"
@@ -48,7 +48,7 @@ pyshark = "^0.6"
 
 [tool.semantic_release]
 branch = "main"
-version_toml = ["pyproject.toml", "tool.poetry.version"]
+version_toml = ["pyproject.toml:tool.poetry.version"]
 build_command = "pip install poetry && poetry build"
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
Okay I ran semantic release locally and it worked with this. Grabbed directly from their config