### PR TITLE
fix: repair semantic release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,26 +75,11 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-
-    - uses: snok/install-poetry@v1.4.1
-
-    - name: Install Dependencies
-      run: poetry install
-      shell: bash
-    - name: Configure Git
-      run: |
-        git config user.name "github-actions"
-        git config user.email "actions@users.noreply.github.com"
-        git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/humbertogontijo/python-roborock.git
     - name: Python Semantic Release
       id: release
       uses: python-semantic-release/python-semantic-release@v9.14.0
       with:
-        github_token: ${{ secrets.GH_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@v1.12.2
@@ -107,4 +92,4 @@ jobs:
       uses: python-semantic-release/upload-to-gh-release@v8.7.0
       if: steps.release.outputs.released == 'true'
       with:
-        github_token: ${{ secrets.GH_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This works on the release branch. If I have the valid permissions, it should work here as well.

You could potentially add : "semantic-release" to overrides for branch protections. I do seem to have more permissions, but I can't see the settings page to do it myself. Hopefully it should work with my github_token