### PR TITLE
fix: add support for QRevo Master mop mode

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -304,6 +304,15 @@ class RoborockMopModeS8MaxVUltra(RoborockMopModeCode):
     smart_mode = 306
 
 
+class RoborockMopModeQRevoMaster(RoborockMopModeCode):
+    standard = 300
+    deep = 301
+    custom = 302
+    deep_plus = 303
+    fast = 304
+    smart_mode = 306
+
+
 class RoborockMopIntensityCode(RoborockEnum):
     """Describes the mop intensity of the vacuum cleaner."""
 

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -39,6 +39,7 @@ from .code_mappings import (
     RoborockMopModeS7,
     RoborockMopModeS8MaxVUltra,
     RoborockMopModeS8ProUltra,
+    RoborockMopModeQRevoMaster,
     RoborockStartType,
     RoborockStateCode,
 )
@@ -577,7 +578,7 @@ class Q7MaxStatus(Status):
 class QRevoMasterStatus(Status):
     fan_power: RoborockFanSpeedQRevoMaster | None = None
     water_box_mode: RoborockMopIntensityQRevoMaster | None = None
-    mop_mode: RoborockMopModeS7 | None = None
+    mop_mode: RoborockMopModeQRevoMaster | None = None
 
 
 @dataclass


### PR DESCRIPTION
The QRevo Master mop mode was missing and was preventing successful initialization of the Roborock Home Assistant component.