### PR TITLE
fix: update log message to include existing request id

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -116,8 +116,10 @@ class RoborockClient:
         if request_id in self._waiting_queue:
             new_id = get_next_int(10000, 32767)
             _LOGGER.warning(
-                f"Attempting to create a future with an existing request_id... New id is {new_id}. "
-                f"Code may not function properly."
+                "Attempting to create a future with an existing id %s... New id is %s. "
+                "Code may not function properly.",
+                request_id,
+                new_id,
             )
             request_id = new_id
         self._waiting_queue[request_id] = queue

--- a/roborock/api.py
+++ b/roborock/api.py
@@ -116,9 +116,10 @@ class RoborockClient:
         if request_id in self._waiting_queue:
             new_id = get_next_int(10000, 32767)
             _LOGGER.warning(
-                "Attempting to create a future with an existing id %s... New id is %s. "
+                "Attempting to create a future with an existing id %s (%s)... New id is %s. "
                 "Code may not function properly.",
                 request_id,
+                protocol_id,
                 new_id,
             )
             request_id = new_id


### PR DESCRIPTION
Update log message about invalid state to also include existing request id. Some requests are sent with a fixed id so would be good to rule those out.

Updates #228