### PR TITLE
chore: always use time.monotonic

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -7,7 +7,7 @@ import base64
 import logging
 import secrets
 import time
-from collections.abc import Callable, Coroutine
+from collections.abc import Coroutine
 from typing import Any
 
 from .containers import (
@@ -36,8 +36,8 @@ class RoborockClient:
         self._endpoint = endpoint
         self._nonce = secrets.token_bytes(16)
         self._waiting_queue: dict[int, RoborockFuture] = {}
-        self._last_device_msg_in = self.time_func()
-        self._last_disconnection = self.time_func()
+        self._last_device_msg_in = time.monotonic()
+        self._last_disconnection = time.monotonic()
         self.keep_alive = KEEPALIVE
         self._diagnostic_data: dict[str, dict[str, Any]] = {
             "misc_info": {"Nonce": base64.b64encode(self._nonce).decode("utf-8")}
@@ -59,15 +59,6 @@ class RoborockClient:
     def diagnostic_data(self) -> dict:
         return self._diagnostic_data
 
-    @property
-    def time_func(self) -> Callable[[], float]:
-        try:
-            # Use monotonic clock if available
-            time_func = time.monotonic
-        except AttributeError:
-            time_func = time.time
-        return time_func
-
     async def async_connect(self):
         raise NotImplementedError
 
@@ -81,13 +72,13 @@ class RoborockClient:
         raise NotImplementedError
 
     def on_connection_lost(self, exc: Exception | None) -> None:
-        self._last_disconnection = self.time_func()
+        self._last_disconnection = time.monotonic()
         self._logger.info("Roborock client disconnected")
         if exc is not None:
             self._logger.warning(exc)
 
     def should_keepalive(self) -> bool:
-        now = self.time_func()
+        now = time.monotonic()
         # noinspection PyUnresolvedReferences
         if now - self._last_disconnection > self.keep_alive**2 and now - self._last_device_msg_in > self.keep_alive:
             return False

--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -361,7 +361,7 @@ class RoborockClientV1(RoborockClient):
 
     def on_message_received(self, messages: list[RoborockMessage]) -> None:
         try:
-            self._last_device_msg_in = self.time_func()
+            self._last_device_msg_in = time.monotonic()
             for data in messages:
                 protocol = data.protocol
                 if data.payload and protocol in [


### PR DESCRIPTION
Update code to always use  time.monotonic since this is now always available in the required library python version. The motivation is to reduce the number of calls to methods in base classes to reduce the class hierarchy. 

Issue #228