### PR TITLE
fix: add additional log messages to track down concurrency errors

### DIFF
--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -391,6 +391,8 @@ class RoborockClientV1(RoborockClient):
                                     if isinstance(result, list) and len(result) == 1:
                                         result = result[0]
                                     queue.resolve((result, None))
+                            else:
+                                self._logger.debug("Received response for unknown request id %s", request_id)
                         else:
                             try:
                                 data_protocol = RoborockDataProtocol(int(data_point_number))
@@ -443,10 +445,14 @@ class RoborockClientV1(RoborockClient):
                             if isinstance(decompressed, list):
                                 decompressed = decompressed[0]
                             queue.resolve((decompressed, None))
+                        else:
+                            self._logger.debug("Received response for unknown request id %s", request_id)
                 else:
                     queue = self._waiting_queue.get(data.seq)
                     if queue:
                         queue.resolve((data.payload, None))
+                    else:
+                        self._logger.debug("Received response for unknown request id %s", data.seq)
         except Exception as ex:
             self._logger.exception(ex)
 

--- a/roborock/version_1_apis/roborock_local_client_v1.py
+++ b/roborock/version_1_apis/roborock_local_client_v1.py
@@ -18,6 +18,7 @@ class RoborockLocalClientV1(RoborockLocalClient, RoborockClientV1):
     ) -> RoborockMessage:
         secured = True if method in COMMANDS_SECURED else False
         request_id, timestamp, payload = self._get_payload(method, params, secured)
+        self._logger.debug("Building message id %s for method %s", request_id, method)
         request_protocol = RoborockMessageProtocol.GENERAL_REQUEST
         message_retry: MessageRetry | None = None
         if method == RoborockCommand.RETRY_REQUEST and isinstance(params, dict):

--- a/roborock/version_1_apis/roborock_mqtt_client_v1.py
+++ b/roborock/version_1_apis/roborock_mqtt_client_v1.py
@@ -74,6 +74,7 @@ class RoborockMqttClientV1(RoborockMqttClient, RoborockClientV1):
             # When we have more custom commands do something more complicated here
             return await self._get_calibration_points()
         request_id, timestamp, payload = self._get_payload(method, params, True)
+        self._logger.debug("Building message id %s for method %s", request_id, method)
         request_protocol = RoborockMessageProtocol.RPC_REQUEST
         roborock_message = RoborockMessage(timestamp=timestamp, protocol=request_protocol, payload=payload)
         return await self.send_message(roborock_message)


### PR DESCRIPTION
Add additional log messages to track down request id assignments and possible mismatches by logging right after request ids are generated.  Getting a request for a message in the queue is probably a "shouldn't happen" case so also add a log message there.