### PR TITLE
chore: Increase test timeout to 30 seconds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,4 +75,4 @@ select=["E", "F", "UP", "I"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-timeout = 20
+timeout = 30


### PR DESCRIPTION
Increase the test timeout to 30 seconds since sometimes it runs slightly behind on a loaded CI machine. If this still is not stable we can look into other fixes.