### PR TITLE
feat: Add Saros 10 code mappings

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -300,6 +300,17 @@ class RoborockFanSpeedS8MaxVUltra(RoborockFanPowerCode):
     smart_mode = 110
 
 
+class RoborockFanSpeedSaros10(RoborockFanPowerCode):
+    off = 105
+    quiet = 101
+    balanced = 102
+    turbo = 103
+    max = 104
+    custom = 106
+    max_plus = 108
+    smart_mode = 110
+
+
 class RoborockFanSpeedSaros10R(RoborockFanPowerCode):
     off = 105
     quiet = 101
@@ -371,6 +382,15 @@ class RoborockMopModeQRevoMaster(RoborockMopModeCode):
 
 
 class RoborockMopModeQRevoMaxV(RoborockMopModeCode):
+    standard = 300
+    deep = 301
+    custom = 302
+    deep_plus = 303
+    fast = 304
+    smart_mode = 306
+
+
+class RoborockMopModeSaros10(RoborockMopModeCode):
     standard = 300
     deep = 301
     custom = 302
@@ -456,6 +476,16 @@ class RoborockMopIntensityS8MaxVUltra(RoborockMopIntensityCode):
     max = 208
     smart_mode = 209
     custom_water_flow = 207
+
+
+class RoborockMopIntensitySaros10(RoborockMopIntensityCode):
+    off = 200
+    mild = 201
+    standard = 202
+    intense = 203
+    extreme = 208
+    custom = 204
+    smart_mode = 209
 
 
 class RoborockMopIntensitySaros10R(RoborockMopIntensityCode):

--- a/roborock/const.py
+++ b/roborock/const.py
@@ -51,6 +51,7 @@ ROBOROCK_QREVO_S = "roborock.vacuum.a104"
 ROBOROCK_QREVO_PRO = "roborock.vacuum.a101"
 ROBOROCK_QREVO_MAXV = "roborock.vacuum.a87"
 ROBOROCK_SAROS_10R = "roborock.vacuum.a144"
+ROBOROCK_SAROS_10 = "roborock.vacuum.a147"
 
 ROBOROCK_DYAD_AIR = "roborock.wetdryvac.a107"
 ROBOROCK_DYAD_PRO_COMBO = "roborock.wetdryvac.a83"

--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -28,6 +28,7 @@ from .code_mappings import (
     RoborockFanSpeedS7,
     RoborockFanSpeedS7MaxV,
     RoborockFanSpeedS8MaxVUltra,
+    RoborockFanSpeedSaros10,
     RoborockFanSpeedSaros10R,
     RoborockFinishReason,
     RoborockInCleaning,
@@ -41,6 +42,7 @@ from .code_mappings import (
     RoborockMopIntensityS6MaxV,
     RoborockMopIntensityS7,
     RoborockMopIntensityS8MaxVUltra,
+    RoborockMopIntensitySaros10,
     RoborockMopIntensitySaros10R,
     RoborockMopModeCode,
     RoborockMopModeQRevoCurv,
@@ -49,6 +51,7 @@ from .code_mappings import (
     RoborockMopModeS7,
     RoborockMopModeS8MaxVUltra,
     RoborockMopModeS8ProUltra,
+    RoborockMopModeSaros10,
     RoborockMopModeSaros10R,
     RoborockStartType,
     RoborockStateCode,
@@ -77,6 +80,7 @@ from .const import (
     ROBOROCK_S8,
     ROBOROCK_S8_MAXV_ULTRA,
     ROBOROCK_S8_PRO_ULTRA,
+    ROBOROCK_SAROS_10,
     ROBOROCK_SAROS_10R,
     SENSOR_DIRTY_REPLACE_TIME,
     SIDE_BRUSH_REPLACE_TIME,
@@ -689,6 +693,13 @@ class Saros10RStatus(Status):
     mop_mode: RoborockMopModeSaros10R | None = None
 
 
+@dataclass
+class Saros10Status(Status):
+    fan_power: RoborockFanSpeedSaros10 | None = None
+    water_box_mode: RoborockMopIntensitySaros10 | None = None
+    mop_mode: RoborockMopModeSaros10 | None = None
+
+
 ModelStatus: dict[str, type[Status]] = {
     ROBOROCK_S4_MAX: S4MaxStatus,
     ROBOROCK_S5_MAX: S5MaxStatus,
@@ -713,6 +724,7 @@ ModelStatus: dict[str, type[Status]] = {
     ROBOROCK_QREVO_PRO: P10Status,
     ROBOROCK_S8_MAXV_ULTRA: S8MaxvUltraStatus,
     ROBOROCK_SAROS_10R: Saros10RStatus,
+    ROBOROCK_SAROS_10: Saros10Status,
 }
 
 


### PR DESCRIPTION
The codes are equal to #415, but the names are different. I also can't confirm the `vac_followed_by_mop` code so I havent added it yet.