### PR TITLE
chore: remove dependencies on `get_request_id` by changing where RequestMessage request_id is set

### DIFF
--- a/roborock/devices/v1_rpc_channel.py
+++ b/roborock/devices/v1_rpc_channel.py
@@ -14,12 +14,11 @@ from roborock.containers import RoborockBase
 from roborock.protocols.v1_protocol import (
     CommandType,
     ParamsType,
+    RequestMessage,
     SecurityData,
-    create_mqtt_payload_encoder,
     decode_rpc_response,
-    encode_local_payload,
 )
-from roborock.roborock_message import RoborockMessage
+from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
 
 from .local_channel import LocalChannel
 from .mqtt_channel import MqttChannel
@@ -116,7 +115,7 @@ class PayloadEncodedV1RpcChannel(BaseV1RpcChannel):
         self,
         name: str,
         channel: MqttChannel | LocalChannel,
-        payload_encoder: Callable[[CommandType, ParamsType], RoborockMessage],
+        payload_encoder: Callable[[RequestMessage], RoborockMessage],
     ) -> None:
         """Initialize the channel with a raw channel and an encoder function."""
         self._name = name
@@ -131,18 +130,26 @@ class PayloadEncodedV1RpcChannel(BaseV1RpcChannel):
     ) -> Any:
         """Send a command and return a parsed response RoborockBase type."""
         _LOGGER.debug("Sending command (%s): %s, params=%s", self._name, method, params)
-        message = self._payload_encoder(method, params)
+        request_message = RequestMessage(method, params=params)
+        message = self._payload_encoder(request_message)
         response = await self._channel.send_message(message)
         return decode_rpc_response(response)
 
 
 def create_mqtt_rpc_channel(mqtt_channel: MqttChannel, security_data: SecurityData) -> V1RpcChannel:
     """Create a V1 RPC channel using an MQTT channel."""
-    payload_encoder = create_mqtt_payload_encoder(security_data)
-    return PayloadEncodedV1RpcChannel("mqtt", mqtt_channel, payload_encoder)
+    return PayloadEncodedV1RpcChannel(
+        "mqtt",
+        mqtt_channel,
+        lambda x: x.encode_message(RoborockMessageProtocol.RPC_REQUEST, security_data=security_data),
+    )
 
 
 def create_combined_rpc_channel(local_channel: LocalChannel, mqtt_rpc_channel: V1RpcChannel) -> V1RpcChannel:
     """Create a V1 RPC channel that combines local and MQTT channels."""
-    local_rpc_channel = PayloadEncodedV1RpcChannel("local", local_channel, encode_local_payload)
+    local_rpc_channel = PayloadEncodedV1RpcChannel(
+        "local",
+        local_channel,
+        lambda x: x.encode_message(RoborockMessageProtocol.GENERAL_REQUEST),
+    )
     return CombinedV1RpcChannel(local_channel, local_rpc_channel, mqtt_rpc_channel)

--- a/roborock/protocols/v1_protocol.py
+++ b/roborock/protocols/v1_protocol.py
@@ -25,8 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 __all__ = [
     "SecurityData",
     "create_security_data",
-    "create_mqtt_payload_encoder",
-    "encode_local_payload",
     "decode_rpc_response",
 ]
 
@@ -66,7 +64,19 @@ class RequestMessage:
     timestamp: int = field(default_factory=lambda: math.floor(time.time()))
     request_id: int = field(default_factory=lambda: get_next_int(10000, 32767))
 
-    def as_payload(self, security_data: SecurityData | None) -> bytes:
+    def encode_message(
+        self,
+        protocol: RoborockMessageProtocol,
+        security_data: SecurityData | None = None,
+    ) -> RoborockMessage:
+        """Convert the request message to a RoborockMessage."""
+        return RoborockMessage(
+            timestamp=self.timestamp,
+            protocol=protocol,
+            payload=self._as_payload(security_data=security_data),
+        )
+
+    def _as_payload(self, security_data: SecurityData | None) -> bytes:
         """Convert the request arguments to a dictionary."""
         inner = {
             "id": self.request_id,
@@ -83,35 +93,6 @@ class RequestMessage:
                 separators=(",", ":"),
             ).encode()
         )
-
-
-def create_mqtt_payload_encoder(security_data: SecurityData) -> Callable[[CommandType, ParamsType], RoborockMessage]:
-    """Create a payload encoder for V1 commands over MQTT."""
-
-    def _get_payload(method: CommandType, params: ParamsType) -> RoborockMessage:
-        """Build the payload for a V1 command."""
-        request = RequestMessage(method=method, params=params)
-        payload = request.as_payload(security_data)  # always secure
-        return RoborockMessage(
-            timestamp=request.timestamp,
-            protocol=RoborockMessageProtocol.RPC_REQUEST,
-            payload=payload,
-        )
-
-    return _get_payload
-
-
-def encode_local_payload(method: CommandType, params: ParamsType) -> RoborockMessage:
-    """Encode payload for V1 commands over local connection."""
-
-    request = RequestMessage(method=method, params=params)
-    payload = request.as_payload(security_data=None)
-
-    return RoborockMessage(
-        timestamp=request.timestamp,
-        protocol=RoborockMessageProtocol.GENERAL_REQUEST,
-        payload=payload,
-    )
 
 
 def decode_rpc_response(message: RoborockMessage) -> dict[str, Any]:

--- a/tests/protocols/test_v1_protocol.py
+++ b/tests/protocols/test_v1_protocol.py
@@ -10,11 +10,10 @@ from roborock.containers import RoborockBase, UserData
 from roborock.exceptions import RoborockException
 from roborock.protocol import Utils
 from roborock.protocols.v1_protocol import (
+    RequestMessage,
     SecurityData,
     create_map_response_decoder,
-    create_mqtt_payload_encoder,
     decode_rpc_response,
-    encode_local_payload,
 )
 from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
 from roborock.roborock_typing import RoborockCommand
@@ -58,7 +57,7 @@ def request_id_fixture() -> Generator[int, None, None]:
 )
 def test_encode_local_payload(command, params, expected):
     """Test encoding of local payload for V1 commands."""
-    message = encode_local_payload(command, params)
+    message = RequestMessage(command, params).encode_message(RoborockMessageProtocol.GENERAL_REQUEST)
     assert isinstance(message, RoborockMessage)
     assert message.protocol == RoborockMessageProtocol.GENERAL_REQUEST
     assert message.payload == expected
@@ -76,8 +75,8 @@ def test_encode_local_payload(command, params, expected):
 )
 def test_encode_mqtt_payload(command, params, expected):
     """Test encoding of local payload for V1 commands."""
-    encoder = create_mqtt_payload_encoder(SECURITY_DATA)
-    message = encoder(command, params)
+    request_message = RequestMessage(command, params=params)
+    message = request_message.encode_message(RoborockMessageProtocol.RPC_REQUEST, SECURITY_DATA)
     assert isinstance(message, RoborockMessage)
     assert message.protocol == RoborockMessageProtocol.RPC_REQUEST
     assert message.payload == expected


### PR DESCRIPTION
Remove some of the payload encoding abstractions so that we don't need to do a round trip for getting `request_id`. We can just get it directly when it is assigned to the outgoing message.

In a follow up change we will remove `get_request_id` from `RoborockMessage` where the last dependency is in the new mqtt API. This can set us up for making the mqtt channel more appropriate to use for b01 where it doesn't depend on v1 and a01 request id semantics.