### PR TITLE
chore: just install pdoc

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
-      - run: uv pip install .
+      - run: uv pip install pdoc
       - run: pdoc ./roborock -o docs/pdoc
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Realized pip install . did not work as pdoc is in the dev dependencies.

Rather than installing everything though, we should be able to just get away with installing pdoc.