### PR TITLE
chore: add pre commit step for commitlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,9 @@ repos:
             -   id: mypy
                 exclude: cli.py
                 additional_dependencies: [ "types-paho-mqtt" ]
+    -   repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+        rev: v9.23.0
+        hooks:
+            -   id: commitlint
+                stages: [commit-msg]
+                additional_dependencies: ['@commitlint/config-conventional']


### PR DESCRIPTION
Ensures commit is linted properly, can be installed with pre-commit install --hook-type commit-msg

Will probably be good if i build up a contributing.md at some point soon.