### PR TITLE
Truncate debug strings for MapContent

### DIFF
--- a/roborock/devices/traits/v1/map_content.py
+++ b/roborock/devices/traits/v1/map_content.py
@@ -12,6 +12,8 @@ from roborock.roborock_typing import RoborockCommand
 
 _LOGGER = logging.getLogger(__name__)
 
+_TRUNCATE_LENGTH = 20
+
 
 @dataclass
 class MapContent(RoborockBase):
@@ -26,9 +28,10 @@ class MapContent(RoborockBase):
     def __repr__(self) -> str:
         """Return a string representation of the MapContent."""
         img = self.image_content
-        if self.image_content and len(self.image_content) > 20:
-            img = f"{self.image_content[:17]}..."
+        if self.image_content and len(self.image_content) > _TRUNCATE_LENGTH:
+            img = self.image_content[: _TRUNCATE_LENGTH - 3] + b"..."
         return f"MapContent(image_content={img!r}, map_data={self.map_data!r})"
+
 
 @common.map_rpc_channel
 class MapContentTrait(MapContent, common.V1TraitMixin):


### PR DESCRIPTION
Improve debug quality of life by truncating images when debug logging is enabled