### PR TITLE
feat: Rename home_cache to home_map_info

### DIFF
--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -118,7 +118,7 @@ class ConnectionCache(RoborockBase):
     email: str
     home_data: HomeData | None = None
     network_info: dict[str, NetworkInfo] | None = None
-    home_cache: dict[int, CombinedMapInfo] | None = None
+    home_map_info: dict[int, CombinedMapInfo] | None = None
     trait_data: dict[str, Any] | None = None
 
 
@@ -267,7 +267,7 @@ class RoborockContext(Cache):
         return CacheData(
             home_data=connection_cache.home_data,
             network_info=connection_cache.network_info or {},
-            home_cache=connection_cache.home_cache,
+            home_map_info=connection_cache.home_map_info,
             trait_data=connection_cache.trait_data or {},
         )
 
@@ -277,7 +277,7 @@ class RoborockContext(Cache):
         connection_cache = self.cache_data()
         connection_cache.home_data = value.home_data
         connection_cache.network_info = value.network_info
-        connection_cache.home_cache = value.home_cache
+        connection_cache.home_map_info = value.home_map_info
         connection_cache.trait_data = value.trait_data
         self.update(connection_cache)
 
@@ -717,14 +717,14 @@ async def home(ctx, device_id: str, refresh: bool):
         await home_trait.refresh()
 
     # Display the discovered home cache
-    if home_trait.home_cache:
+    if home_trait.home_map_info:
         cache_summary = {
             map_flag: {
                 "name": map_data.name,
                 "room_count": len(map_data.rooms),
                 "rooms": [{"segment_id": room.segment_id, "name": room.name} for room in map_data.rooms],
             }
-            for map_flag, map_data in home_trait.home_cache.items()
+            for map_flag, map_data in home_trait.home_map_info.items()
         }
         click.echo(dump_json(cache_summary))
     else:

--- a/roborock/devices/cache.py
+++ b/roborock/devices/cache.py
@@ -22,8 +22,8 @@ class CacheData:
     network_info: dict[str, NetworkInfo] = field(default_factory=dict)
     """Network information indexed by device DUID."""
 
-    home_cache: dict[int, CombinedMapInfo] = field(default_factory=dict)
-    """Home cache information indexed by map_flag."""
+    home_map_info: dict[int, CombinedMapInfo] = field(default_factory=dict)
+    """Home map information indexed by map_flag."""
 
     device_features: DeviceFeatures | None = None
     """Device features information."""

--- a/tests/devices/traits/v1/test_home.py
+++ b/tests/devices/traits/v1/test_home.py
@@ -125,18 +125,18 @@ async def test_discover_home_empty_cache(
     ]
 
     # Before discovery, no cache should exist
-    assert home_trait.home_cache is None
+    assert home_trait.home_map_info is None
     assert home_trait.current_map_data is None
 
     # Perform home discovery
     await home_trait.discover_home()
 
     # Verify cache is populated
-    assert home_trait.home_cache is not None
-    assert len(home_trait.home_cache) == 2
+    assert home_trait.home_map_info is not None
+    assert len(home_trait.home_map_info) == 2
 
     # Check map 0 data
-    map_0_data = home_trait.home_cache[0]
+    map_0_data = home_trait.home_map_info[0]
     assert map_0_data.map_flag == 0
     assert map_0_data.name == "Ground Floor"
     assert len(map_0_data.rooms) == 2
@@ -146,7 +146,7 @@ async def test_discover_home_empty_cache(
     assert map_0_data.rooms[1].name == "Example room 2"
 
     # Check map 123 data
-    map_123_data = home_trait.home_cache[123]
+    map_123_data = home_trait.home_map_info[123]
     assert map_123_data.map_flag == 123
     assert map_123_data.name == "Second Floor"
     assert len(map_123_data.rooms) == 2
@@ -170,7 +170,7 @@ async def test_discover_home_with_existing_cache(
     """Test that discovery is skipped when cache already exists."""
     # Pre-populate the cache
     cache_data = await home_trait._cache.get()
-    cache_data.home_cache = {0: CombinedMapInfo(map_flag=0, name="Dummy", rooms=[])}
+    cache_data.home_map_info = {0: CombinedMapInfo(map_flag=0, name="Dummy", rooms=[])}
     await home_trait._cache.set(cache_data)
 
     # Call discover_home
@@ -181,7 +181,7 @@ async def test_discover_home_with_existing_cache(
     assert mock_mqtt_rpc_channel.send_command.call_count == 0
 
     # Verify cache was loaded from storage
-    assert home_trait.home_cache == {0: CombinedMapInfo(map_flag=0, name="Dummy", rooms=[])}
+    assert home_trait.home_map_info == {0: CombinedMapInfo(map_flag=0, name="Dummy", rooms=[])}
 
 
 async def test_discover_home_no_maps(
@@ -209,9 +209,9 @@ async def test_refresh_updates_current_map_cache(
     # Pre-populate cache with some data
     cache_data = await home_trait._cache.get()
 
-    cache_data.home_cache = {0: CombinedMapInfo(map_flag=0, name="Old Ground Floor", rooms=[])}
+    cache_data.home_map_info = {0: CombinedMapInfo(map_flag=0, name="Old Ground Floor", rooms=[])}
     await home_trait._cache.set(cache_data)
-    home_trait._home_cache = cache_data.home_cache
+    home_trait._home_map_info = cache_data.home_map_info
 
     # Setup mocks for refresh
     mock_rpc_channel.send_command.side_effect = [
@@ -225,7 +225,7 @@ async def test_refresh_updates_current_map_cache(
     await home_trait.refresh()
 
     # Verify cache was updated for current map
-    updated_cache = home_trait.home_cache
+    updated_cache = home_trait.home_map_info
     assert updated_cache is not None
     assert 0 in updated_cache
 
@@ -277,7 +277,7 @@ async def test_current_map_data_property(
     assert current_data.name == "Ground Floor"
 
     # Test when no cache exists
-    home_trait._home_cache = None
+    home_trait._home_map_info = None
     assert home_trait.current_map_data is None
 
 
@@ -333,9 +333,9 @@ async def test_single_map_no_switching(
     await home_trait.discover_home()
 
     # Verify cache is populated
-    assert home_trait.home_cache is not None
-    assert len(home_trait.home_cache) == 1
-    assert 0 in home_trait.home_cache
+    assert home_trait.home_map_info is not None
+    assert len(home_trait.home_map_info) == 1
+    assert 0 in home_trait.home_map_info
 
     # Verify no LOAD_MULTI_MAP commands were sent (no map switching)
     load_map_calls = [


### PR DESCRIPTION
This breaks the API to rename the accessors in preparation for also storing map content. Making this change now while there are still no dependencies.