### PR TITLE
chore: disable body-max-line-length

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -4,6 +4,8 @@ export default {
     rules: {
         // Disable the rule that enforces lowercase in subject
         "subject-case": [0], // 0 = disable, 1 = warn, 2 = error
+        // Disable the rule that enforces a maximum line length in the body
+        "body-max-line-length": [0, "always"]
     },
 
 };


### PR DESCRIPTION
Disable the rule that enforces max commit body line length, since i don't think we need it and it is one that always fails for me.