### PR TITLE
fix: Fix DeviceFeatures so that it can be serialized and deserialized properly

### DIFF
--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -38,7 +38,7 @@
 | `is_carpet_shape_type_supported` |  |  |  |
 | `is_carpet_show_on_map` |  | X |  |
 | `is_carpet_supported` | X | X |  |
-| `is_ces2022_supported` |  |  |  |
+| `is_ces_2022_supported` |  |  |  |
 | `is_clean_count_setting_supported` |  | X |  |
 | `is_clean_direct_status_supported` |  |  |  |
 | `is_clean_efficiency_supported` |  |  |  |

--- a/roborock/device_features.py
+++ b/roborock/device_features.py
@@ -313,7 +313,7 @@ class DeviceFeatures(RoborockBase):
     is_support_incremental_map: bool = field(metadata={"new_feature_str_mask": (4194304, 8)})
     is_offline_map_supported: bool = field(metadata={"new_feature_str_mask": (16384, 8)})
     is_super_deep_wash_supported: bool = field(metadata={"new_feature_str_mask": (32768, 8)})
-    is_ces2022_supported: bool = field(metadata={"new_feature_str_mask": (65536, 8)})
+    is_ces_2022_supported: bool = field(metadata={"new_feature_str_mask": (65536, 8)})
     is_dss_believable: bool = field(metadata={"new_feature_str_mask": (131072, 8)})
     is_main_brush_up_down_supported_from_str: bool = field(metadata={"new_feature_str_mask": (262144, 8)})
     is_goto_pure_clean_path_supported: bool = field(metadata={"new_feature_str_mask": (524288, 8)})

--- a/tests/test_supported_features.py
+++ b/tests/test_supported_features.py
@@ -1,4 +1,7 @@
+from syrupy import SnapshotAssertion
+
 from roborock import SHORT_MODEL_TO_ENUM
+from roborock.data.code_mappings import RoborockProductNickname
 from roborock.device_features import DeviceFeatures
 
 
@@ -43,3 +46,16 @@ def test_supported_features_s7():
     assert not device_features.is_hot_wash_towel_supported
     num_true = sum(vars(device_features).values())
     assert num_true != 0
+
+
+def test_device_feature_serialization(snapshot: SnapshotAssertion) -> None:
+    """Test serialization and deserialization of DeviceFeatures."""
+    device_features = DeviceFeatures.from_feature_flags(
+        new_feature_info=636084721975295,
+        new_feature_info_str="0000000000002000",
+        feature_info=[111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 122, 123, 124, 125],
+        product_nickname=RoborockProductNickname.TANOSS,
+    )
+    serialized = device_features.as_dict()
+    deserialized = DeviceFeatures.from_dict(serialized)
+    assert deserialized == device_features


### PR DESCRIPTION
Adds tests for the desired output, then update the algorithm to make the tests path (AI assisted).

This needs additional support because (1) the naming of variables for device features are more complex than other fields and (2) the typing of a dict of boolean fields is unique to DeviceFeatures.

This adds a few variations of tests for different forms of coverage from:
- Device features itself
- Test objects with similar behaviors
- Camelize/decamelize functions themselves

Required to fix https://github.com/home-assistant/core/issues/157663