### PR TITLE
fix: Update logging to be more conservative

### DIFF
--- a/roborock/devices/local_channel.py
+++ b/roborock/devices/local_channel.py
@@ -186,7 +186,7 @@ class LocalChannel(Channel):
 
     def _connection_lost(self, exc: Exception | None) -> None:
         """Handle connection loss."""
-        _LOGGER.warning("Connection lost to %s", self._host, exc_info=exc)
+        _LOGGER.debug("Local connection lost to %s", self._host, exc_info=exc)
         self._transport = None
         self._is_connected = False
 


### PR DESCRIPTION
We currently log warning logs on local disconnects. This is moved to log info and instead we should let the caller log warnings when RPCs fail etc. This will log at the info level only after failures to reconnect, but then logs again when reconnect happens.