### PR TITLE
fix: Catch UnicodeDecodeError when parsing messages

### DIFF
--- a/roborock/protocols/v1_protocol.py
+++ b/roborock/protocols/v1_protocol.py
@@ -135,7 +135,7 @@ def decode_rpc_response(message: RoborockMessage) -> ResponseMessage:
         return ResponseMessage(request_id=message.seq, data={})
     try:
         payload = json.loads(message.payload.decode())
-    except (json.JSONDecodeError, TypeError) as e:
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as e:
         raise RoborockException(f"Invalid V1 message payload: {e} for {message.payload!r}") from e
 
     _LOGGER.debug("Decoded V1 message payload: %s", payload)

--- a/tests/protocols/test_v1_protocol.py
+++ b/tests/protocols/test_v1_protocol.py
@@ -274,3 +274,17 @@ def test_decode_no_request_id():
     )
     with pytest.raises(RoborockException, match="The method called is not recognized by the device"):
         decode_rpc_response(message)
+
+
+def test_invalid_unicode() -> None:
+    """Test an error while decoding unicode bytes"""
+    message = RoborockMessage(
+        protocol=RoborockMessageProtocol.GENERAL_RESPONSE,
+        payload=b"hello\xff\xfe",  # Invalid UTF-8 bytes
+        seq=12750,
+        version=b"1.0",
+        random=97431,
+        timestamp=1652547161,
+    )
+    with pytest.raises(RoborockException, match="Invalid V1 message payload"):
+        decode_rpc_response(message)


### PR DESCRIPTION
Fixes this error message:
```
Uncaught error in callback 'find_response': 'utf-8' codec can't decode byte 0x9d in position 24: invalid start byte 2025-12-04 08:02:40.468 
```

This will cause invalid mqtt messages to be ignored and not logged. I suspect this is normal when attempting to parse an mqtt message as a map message? Or may indicate another problem we have not yet diagnosed, but still needed.