### PR TITLE
fix: ensure keys are correct type when serializing from data

### DIFF
--- a/roborock/data/containers.py
+++ b/roborock/data/containers.py
@@ -68,7 +68,9 @@ class RoborockBase:
             return [RoborockBase._convert_to_class_obj(sub_type, obj) for obj in value]
         if get_origin(class_type) is dict:
             key_type, value_type = get_args(class_type)
-            return {key_type(k): RoborockBase._convert_to_class_obj(value_type, v) for k, v in value.items()}
+            if key_type is not None:
+                return {key_type(k): RoborockBase._convert_to_class_obj(value_type, v) for k, v in value.items()}
+            return {k: RoborockBase._convert_to_class_obj(value_type, v) for k, v in value.items()}
         if inspect.isclass(class_type):
             if issubclass(class_type, RoborockBase):
                 return class_type.from_dict(value)


### PR DESCRIPTION
So the problem for the unique ids is that we were getting duplicates in the home data info.

this happened because when we dump to a json file, the json saves the int key as a str. When we load it back, we load it as a str. Then we get the new home data and we add the ints. Now we have both a str and a int version of the same data.

 previously we did not do any casting for the keys of dictionaries.

Now we do some basic casting to ensure it is the right type.