### PR TITLE
fix: Throw MQTT authentication errors as authentication related exceptions

### DIFF
--- a/roborock/mqtt/roborock_session.py
+++ b/roborock/mqtt/roborock_session.py
@@ -18,9 +18,8 @@ import aiomqtt
 from aiomqtt import MqttCodeError, MqttError, TLSParameters
 
 from roborock.callbacks import CallbackMap
-from roborock.exceptions import RoborockInvalidCredentials
 
-from .session import MqttParams, MqttSession, MqttSessionException
+from .session import MqttParams, MqttSession, MqttSessionException, MqttSessionUnauthorized
 
 _LOGGER = logging.getLogger(__name__)
 _MQTT_LOGGER = logging.getLogger(f"{__name__}.aiomqtt")
@@ -96,7 +95,7 @@ class RoborockMqttSession(MqttSession):
             await start_future
         except MqttCodeError as err:
             if err.rc == MqttReasonCode.RC_ERROR_UNAUTHORIZED:
-                raise RoborockInvalidCredentials(f"Authorization error starting MQTT session: {err}") from err
+                raise MqttSessionUnauthorized(f"Authorization error starting MQTT session: {err}") from err
             raise MqttSessionException(f"Error starting MQTT session: {err}") from err
         except MqttError as err:
             raise MqttSessionException(f"Error starting MQTT session: {err}") from err

--- a/roborock/mqtt/session.py
+++ b/roborock/mqtt/session.py
@@ -64,9 +64,17 @@ class MqttSession(ABC):
 
 
 class MqttSessionException(RoborockException):
-    """Raised when there is an error communicating with MQTT.
+    """Raised when there is an error communicating with MQTT."""
 
-    Note that not all exceptions raised by the MQTT session are of this type
-    as other `RoborockException`s may be raised for specific error conditions
-    such as authentication errors.
+
+class MqttSessionUnauthorized(RoborockException):
+    """Raised when there is an authorization error communicating with MQTT.
+
+    This error may be raised in multiple scenarios so there is not a well
+    defined behavior for how the caller should behave. The two cases are:
+    - Rate limiting is in effect and the caller should retry after some time.
+    - The credentials are invalid and the caller needs to obtain new credentials
+
+    However, it is observed that obtaining new credentials may resolve the
+    issue in both cases.
     """

--- a/tests/mqtt/test_roborock_session.py
+++ b/tests/mqtt/test_roborock_session.py
@@ -11,9 +11,8 @@ import aiomqtt
 import paho.mqtt.client as mqtt
 import pytest
 
-from roborock.exceptions import RoborockInvalidCredentials
 from roborock.mqtt.roborock_session import RoborockMqttSession, create_mqtt_session
-from roborock.mqtt.session import MqttParams, MqttSessionException
+from roborock.mqtt.session import MqttParams, MqttSessionException, MqttSessionUnauthorized
 from tests import mqtt_packet
 from tests.conftest import FakeSocketHandler
 
@@ -379,7 +378,7 @@ async def test_idle_timeout_multiple_callbacks(mock_mqtt_client: AsyncMock) -> N
         ),
         (
             aiomqtt.MqttCodeError(rc=135),
-            RoborockInvalidCredentials,
+            MqttSessionUnauthorized,
             "Authorization error starting MQTT session",
         ),
         (


### PR DESCRIPTION
Update the MQTT exception handling to carve out a different exception type for authorization errors.  Today callers do not have the ability to handle special authentication errors like this:
```
2025-12-05 13:42:39.684 INFO (MainThread) [roborock.mqtt.roborock_session] MQTT error starting session: [code:135] Not authorized
```
Now this will be thrown with `RoborockInvalidCredentials`.  Callers can catch this  to know when they need to re-authenticate a device and obtain new mqtt params.