### PR TITLE
feat: Add mappings for cleaning fluid states.

### DIFF
--- a/roborock/data/v1/v1_code_mappings.py
+++ b/roborock/data/v1/v1_code_mappings.py
@@ -123,6 +123,13 @@ class DustBagStatus(RoborockDssCodes):
     full = 34
 
 
+class CleanFluidStatus(RoborockDssCodes):
+    """Status of the cleaning fluid container."""
+
+    empty_not_installed = 1
+    okay = 2
+
+
 class RoborockErrorCode(RoborockEnum):
     none = 0
     lidar_blocked = 1

--- a/roborock/data/v1/v1_containers.py
+++ b/roborock/data/v1/v1_containers.py
@@ -39,6 +39,7 @@ from roborock.exceptions import RoborockException
 
 from ..containers import RoborockBase, RoborockBaseTimer, _attr_repr
 from .v1_code_mappings import (
+    CleanFluidStatus,
     ClearWaterBoxStatus,
     DirtyWaterBoxStatus,
     DustBagStatus,
@@ -229,9 +230,12 @@ class Status(RoborockBase):
         return None
 
     @property
-    def clean_fluid_status(self) -> int | None:
+    def clean_fluid_status(self) -> CleanFluidStatus | None:
         if self.dss:
-            return (self.dss >> 10) & 3
+            value = (self.dss >> 10) & 3
+            if value == 0:
+                return None  # Feature not supported by this device
+            return CleanFluidStatus(value)
         return None
 
     @property


### PR DESCRIPTION
This PR adds support for tracking the cleaning fluid container status in the Roborock integration. The main changes introduce a new enum for cleaning fluid status, update the container logic to use this enum, and ensure the feature is only reported if supported by the device.

This was tested using the Saros Z70, which has a cleaning fluid dispenser. Also a Qrevo Curv and QX Revo Ultra which do not have cleaning fluid dispensers.