### PR TITLE
fix: Revert CLIENT_KEEPALIVE back to 60

### DIFF
--- a/roborock/mqtt/roborock_session.py
+++ b/roborock/mqtt/roborock_session.py
@@ -24,7 +24,7 @@ from .session import MqttParams, MqttSession, MqttSessionException
 _LOGGER = logging.getLogger(__name__)
 _MQTT_LOGGER = logging.getLogger(f"{__name__}.aiomqtt")
 
-CLIENT_KEEPALIVE = datetime.timedelta(seconds=120)
+CLIENT_KEEPALIVE = datetime.timedelta(seconds=60)
 TOPIC_KEEPALIVE = datetime.timedelta(seconds=60)
 
 # Exponential backoff parameters


### PR DESCRIPTION
This reverts back to the old default since there is no specific reason to change it. This reverts part of https://github.com/Python-roborock/python-roborock/pull/632

Issue #639