### PR TITLE
fix: Consider RPC channel health based on MQTT session

### DIFF
--- a/roborock/devices/v1_channel.py
+++ b/roborock/devices/v1_channel.py
@@ -199,7 +199,7 @@ class V1Channel(Channel):
     @property
     def is_mqtt_connected(self) -> bool:
         """Return whether MQTT connection is available."""
-        return self._mqtt_unsub is not None and self._mqtt_channel.is_connected
+        return self._mqtt_channel.is_connected
 
     @property
     def rpc_channel(self) -> V1RpcChannel:

--- a/tests/devices/test_v1_channel.py
+++ b/tests/devices/test_v1_channel.py
@@ -256,7 +256,7 @@ async def test_v1_channel_subscribe_local_success(
     assert mock_local_channel.subscribers
 
     # Verify properties
-    assert not v1_channel.is_mqtt_connected
+    assert v1_channel.is_mqtt_connected
     assert v1_channel.is_local_connected
 
     # Test unsubscribe cleans up both


### PR DESCRIPTION
Use the MQTT session for the health rather than the "subscription". It is straight foward to add a topic when sending an RPC so we assume we can do that on demand when sending the RPC.

In practice, we don't actually use this for any health checking that is meaningful. However, it seems worth making consistent with our stance on this.