### PR TITLE
fix: redact additional keys from diagnostic data

### DIFF
--- a/roborock/devices/device.py
+++ b/roborock/devices/device.py
@@ -199,7 +199,7 @@ class RoborockDevice(ABC, TraitsMixin):
 T = TypeVar("T")
 
 REDACT_KEYS = {
-    # Sensitive identifiers
+    # Potential identifiers
     "duid",
     "localKey",
     "mac",


### PR DESCRIPTION
Update the list of sensitive/large data in the redacted key list.

Fixes #622
