### PR TITLE
fix: harden the device connection logic used in startup

### DIFF
--- a/roborock/devices/device.py
+++ b/roborock/devices/device.py
@@ -147,8 +147,10 @@ class RoborockDevice(ABC, TraitsMixin):
         called. The device will automatically attempt to reconnect if the connection
         is lost.
         """
-        # We don't care about the value of the future, just that we wait long enough
-        # to let the first connection attempt happen.
+        # The future will be set to True if the first attempt succeeds, False if
+        # it fails, or an exception if an unexpected error occurs.
+        # We use this to wait a short time for the first attempt to complete. We
+        # don't actually care about the result, just that we waited long enough.
         start_attempt: asyncio.Future[bool] = asyncio.Future()
 
         async def connect_loop() -> None:

--- a/tests/devices/test_device_manager.py
+++ b/tests/devices/test_device_manager.py
@@ -252,6 +252,6 @@ async def test_start_connect_failure(home_data: HomeData, channel_failure: Mock,
     ],
 )
 async def test_start_connect_unexpected_error(home_data: HomeData, channel_failure: Mock, mock_sleep: Mock) -> None:
-    """Test that some exceptions from start_connect are propagated."""
+    """Test that some unexpected errors from start_connect are propagated."""
     with pytest.raises(Exception, match="Unexpected error"):
         await create_device_manager(USER_PARAMS)


### PR DESCRIPTION
We currently see "Initial connection attempt took longer than expected" and this is an attempt to see if the reason is due to uncaught exceptions.

This adds some exception handling for uncaught exceptions to make sure the connection attempt gets fired.
