### PR TITLE
fix: Fix diagnostic data redaction to use camelized keys

### DIFF
--- a/roborock/devices/device.py
+++ b/roborock/devices/device.py
@@ -235,9 +235,9 @@ REDACT_KEYS = {
     "h",
     "k",
     # Large binary blobs are entirely omitted
-    "image_content",
-    "map_data",
-    "raw_api_response",
+    "imageContent",
+    "mapData",
+    "rawApiResponse",
 }
 REDACTED = "**REDACTED**"
 


### PR DESCRIPTION
The redaction list doesn't have the right format for some of the keys.