### PR TITLE
fix: Share a HealthManager instance across all mqtt channels

### DIFF
--- a/roborock/devices/mqtt_channel.py
+++ b/roborock/devices/mqtt_channel.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from roborock.callbacks import decoder_callback
 from roborock.data import HomeDataDevice, RRiot, UserData
 from roborock.exceptions import RoborockException
+from roborock.mqtt.health_manager import HealthManager
 from roborock.mqtt.session import MqttParams, MqttSession, MqttSessionException
 from roborock.protocol import create_mqtt_decoder, create_mqtt_encoder
 from roborock.roborock_message import RoborockMessage
@@ -41,6 +42,11 @@ class MqttChannel(Channel):
         This passes through the underlying MQTT session's connected state.
         """
         return self._mqtt_session.connected
+
+    @property
+    def health_manager(self) -> HealthManager:
+        """Return the health manager for the session."""
+        return self._mqtt_session.health_manager
 
     @property
     def is_local_connected(self) -> bool:

--- a/roborock/devices/v1_channel.py
+++ b/roborock/devices/v1_channel.py
@@ -181,7 +181,6 @@ class V1Channel(Channel):
         self._logger = RoborockLoggerAdapter(device_uid, _LOGGER)
         self._security_data = security_data
         self._mqtt_channel = mqtt_channel
-        self._mqtt_health_manager = HealthManager(self._mqtt_channel.restart)
         self._local_session = local_session
         self._local_channel: LocalChannel | None = None
         self._mqtt_unsub: Callable[[], None] | None = None
@@ -272,7 +271,7 @@ class V1Channel(Channel):
                 security_data=self._security_data,
             ),
             decoder=decoder,
-            health_manager=self._mqtt_health_manager,
+            health_manager=self._mqtt_channel.health_manager,
         )
 
     async def subscribe(self, callback: Callable[[RoborockMessage], None]) -> Callable[[], None]:

--- a/roborock/mqtt/roborock_session.py
+++ b/roborock/mqtt/roborock_session.py
@@ -19,6 +19,7 @@ from aiomqtt import MqttCodeError, MqttError, TLSParameters
 
 from roborock.callbacks import CallbackMap
 
+from .health_manager import HealthManager
 from .session import MqttParams, MqttSession, MqttSessionException, MqttSessionUnauthorized
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,11 +75,17 @@ class RoborockMqttSession(MqttSession):
         self._connection_task: asyncio.Task[None] | None = None
         self._topic_idle_timeout = topic_idle_timeout
         self._idle_timers: dict[str, asyncio.Task[None]] = {}
+        self._health_manager = HealthManager(self.restart)
 
     @property
     def connected(self) -> bool:
         """True if the session is connected to the broker."""
         return self._healthy
+
+    @property
+    def health_manager(self) -> HealthManager:
+        """Return the health manager for the session."""
+        return self._health_manager
 
     async def start(self) -> None:
         """Start the MQTT session.
@@ -322,6 +329,11 @@ class LazyMqttSession(MqttSession):
     def connected(self) -> bool:
         """True if the session is connected to the broker."""
         return self._session.connected
+
+    @property
+    def health_manager(self) -> HealthManager:
+        """Return the health manager for the session."""
+        return self._session.health_manager
 
     async def _maybe_start(self) -> None:
         """Start the MQTT session if not already started."""

--- a/roborock/mqtt/session.py
+++ b/roborock/mqtt/session.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from roborock.exceptions import RoborockException
+from roborock.mqtt.health_manager import HealthManager
 
 DEFAULT_TIMEOUT = 30.0
 
@@ -39,6 +40,11 @@ class MqttSession(ABC):
     @abstractmethod
     def connected(self) -> bool:
         """True if the session is connected to the broker."""
+
+    @property
+    @abstractmethod
+    def health_manager(self) -> HealthManager:
+        """Return the health manager for the session."""
 
     @abstractmethod
     async def subscribe(self, device_id: str, callback: Callable[[bytes], None]) -> Callable[[], None]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from aioresponses import aioresponses
 
 from roborock import HomeData, UserData
 from roborock.data import DeviceData
+from roborock.mqtt.health_manager import HealthManager
 from roborock.protocols.v1_protocol import LocalProtocolVersion
 from roborock.roborock_message import RoborockMessage
 from roborock.version_1_apis.roborock_local_client_v1 import RoborockLocalClientV1
@@ -364,6 +365,7 @@ class FakeChannel:
         self.close = MagicMock(side_effect=self._close)
         self.protocol_version = LocalProtocolVersion.V1
         self.restart = AsyncMock()
+        self.health_manager = HealthManager(self.restart)
 
     async def _connect(self) -> None:
         self._is_connected = True


### PR DESCRIPTION
The motiviation is to better isolate single device timeouts from overall session health. I have not seen this as an explicit issue, but seems worth being defensive against. This will ensure that a single inactive device will not unnecessarily restart the MQTT session. Any successful RPCs by other devices will reset the counter.

Adds explicit logging when a session is reset by the health manager.