### PR TITLE
fix: a01 padding

### DIFF
--- a/roborock/protocols/a01_protocol.py
+++ b/roborock/protocols/a01_protocol.py
@@ -57,8 +57,9 @@ def decode_rpc_response(message: RoborockMessage) -> dict[int, Any]:
         raise RoborockException("Invalid A01 message format: missing payload")
     try:
         unpadded = unpad(message.payload, AES.block_size)
-    except ValueError as err:
-        raise RoborockException(f"Unable to unpad A01 payload: {err}")
+    except ValueError:
+        # We should fail down the line if something is wrong with padding. Try to continue.
+        unpadded = message.payload
 
     try:
         payload = json.loads(unpadded.decode())


### PR DESCRIPTION
Handle a failed unpadding by setting the message to the unpadded version. Will run some tests on this to make sure it works, marking as draft for now.