### PR TITLE
fix: Properly shutdown the context in the CLI

### DIFF
--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -93,9 +93,9 @@ def async_command(func):
         async def run():
             try:
                 await func(*args, **kwargs)
-            except Exception:
+            except Exception as err:
                 _LOGGER.exception("Uncaught exception in command")
-                click.echo(f"Error: {sys.exc_info()[1]}", err=True)
+                click.echo(f"Error: {err}", err=True)
             finally:
                 if not context.is_session_mode():
                     await context.cleanup()


### PR DESCRIPTION
This avoids leaving open a session after running commands and properly catches exceptions in the CLI commands.

Pulled out from #709