### PR TITLE
Add s5e device and product data examples

### DIFF
--- a/tests/testdata/home_data_device_s5e.json
+++ b/tests/testdata/home_data_device_s5e.json
@@ -1,0 +1,31 @@
+{
+    "duid": "device-uid-s5e",
+    "name": "Roborock Downstairs",
+    "localKey": "key123key123key1",
+    "productId": "73EnOOM2NhDujvnvb7hvvv",
+    "fv": "02.16.62",
+    "activeTime": 1633770040,
+    "timeZoneId": "America/Los_Angeles",
+    "iconUrl": "",
+    "share": false,
+    "online": true,
+    "pv": "1.0",
+    "tuyaUuid": "tuya-uuid-s5e",
+    "tuyaMigrated": true,
+    "extra": "{\"xxxx\": \"xxxx\", \"roTuyaDid\": \"tuya-did-s5e\", \"roTuyaActiveTime\": 1601112710}",
+    "sn": "sn123sn123sn123sn123",
+    "featureSet": "0",
+    "newFeatureSet": "0000000000002000",
+    "deviceStatus": {
+        "121": 8,
+        "122": 100,
+        "123": 102,
+        "124": 202,
+        "125": 17,
+        "126": 0,
+        "127": 0,
+        "120": 0
+    },
+    "silentOtaSwitch": false,
+    "f": false
+}

--- a/tests/testdata/home_data_product_s5e.json
+++ b/tests/testdata/home_data_product_s5e.json
@@ -1,0 +1,136 @@
+{
+    "id": "73EnOOM2NhDujvnvb7hvvv",
+    "name": "S5 Max",
+    "model": "roborock.vacuum.s5e",
+    "category": "robot.vacuum.cleaner",
+    "capability": 0,
+    "schema": [
+        {
+            "id": 101,
+            "name": "rpc_request",
+            "code": "rpc_request",
+            "mode": "rw",
+            "type": "RAW"
+        },
+        {
+            "id": 102,
+            "name": "rpc_response",
+            "code": "rpc_response",
+            "mode": "rw",
+            "type": "RAW"
+        },
+        {
+            "id": 120,
+            "name": "\u9519\u8bef\u4ee3\u7801",
+            "code": "error_code",
+            "mode": "ro",
+            "type": "ENUM",
+            "property": "{\"range\": []}"
+        },
+        {
+            "id": 121,
+            "name": "\u8bbe\u5907\u72b6\u6001",
+            "code": "state",
+            "mode": "ro",
+            "type": "ENUM",
+            "property": "{\"range\": []}"
+        },
+        {
+            "id": 122,
+            "name": "\u8bbe\u5907\u7535\u91cf",
+            "code": "battery",
+            "mode": "ro",
+            "type": "ENUM",
+            "property": "{\"range\": []}"
+        },
+        {
+            "id": 123,
+            "name": "\u6e05\u626b\u6a21\u5f0f",
+            "code": "fan_power",
+            "mode": "rw",
+            "type": "ENUM",
+            "property": "{\"range\": []}"
+        },
+        {
+            "id": 124,
+            "name": "\u62d6\u5730\u6a21\u5f0f",
+            "code": "water_box_mode",
+            "mode": "rw",
+            "type": "ENUM",
+            "property": "{\"range\": []}"
+        },
+        {
+            "id": 125,
+            "name": "\u4e3b\u5237\u5bff\u547d",
+            "code": "main_brush_life",
+            "mode": "rw",
+            "type": "VALUE",
+            "property": "{\"max\": 100, \"min\": 0, \"step\": 1, \"unit\": null, \"scale\": 1}"
+        },
+        {
+            "id": 126,
+            "name": "\u8fb9\u5237\u5bff\u547d",
+            "code": "side_brush_life",
+            "mode": "rw",
+            "type": "VALUE",
+            "property": "{\"max\": 100, \"min\": 0, \"step\": 1, \"unit\": null, \"scale\": 1}"
+        },
+        {
+            "id": 127,
+            "name": "\u6ee4\u7f51\u5bff\u547d",
+            "code": "filter_life",
+            "mode": "rw",
+            "type": "VALUE",
+            "property": "{\"max\": 100, \"min\": 0, \"step\": 1, \"unit\": null, \"scale\": 1}"
+        },
+        {
+            "id": 128,
+            "name": "\u989d\u5916\u72b6\u6001",
+            "code": "additional_props",
+            "mode": "ro",
+            "type": "RAW"
+        },
+        {
+            "id": 130,
+            "name": "\u5b8c\u6210\u4e8b\u4ef6",
+            "code": "task_complete",
+            "mode": "ro",
+            "type": "RAW"
+        },
+        {
+            "id": 131,
+            "name": "\u7535\u91cf\u4e0d\u8db3\u4efb\u52a1\u53d6\u6d88",
+            "code": "task_cancel_low_power",
+            "mode": "ro",
+            "type": "RAW"
+        },
+        {
+            "id": 132,
+            "name": "\u8fd0\u52a8\u4e2d\u4efb\u52a1\u53d6\u6d88",
+            "code": "task_cancel_in_motion",
+            "mode": "ro",
+            "type": "RAW"
+        },
+        {
+            "id": 133,
+            "name": "\u5145\u7535\u72b6\u6001",
+            "code": "charge_status",
+            "mode": "ro",
+            "type": "RAW"
+        },
+        {
+            "id": 134,
+            "name": "\u70d8\u5e72\u72b6\u6001",
+            "code": "drying_status",
+            "mode": "ro",
+            "type": "RAW"
+        },
+        {
+            "id": 135,
+            "name": "\u79bb\u7ebf\u539f\u56e0\u7ec6\u5206",
+            "code": "offline_status",
+            "mode": "ro",
+            "type": "RAW"
+        }
+    ]
+}


### PR DESCRIPTION
These are not used in any tests, but saved for future use. They are parsed as part of the mock data loading module to verify they are correct, but then not used.