### PR TITLE
fix: decrease home data rate limits

### DIFF
--- a/roborock/web_api.py
+++ b/roborock/web_api.py
@@ -57,8 +57,8 @@ class RoborockApiClient:
     ]
     _HOME_DATA_RATES = [
         Rate(1, Duration.SECOND),
-        Rate(5, Duration.MINUTE),
-        Rate(15, Duration.HOUR),
+        Rate(3, Duration.MINUTE),
+        Rate(5, Duration.HOUR),
         Rate(40, Duration.DAY),
     ]
 


### PR DESCRIPTION
15/hour seems to be too aggressive.

Something on my real instance got mad after the update and failed to get home data repeatedly. I wish I knew the cause, but unfortunately I do not as I did not have debug logging enabled, I just end up seeing the home data bucket full.

My instance ended up causing a slowdown on the app and I believe put itself in a bad state that maybe it continued to fail to get home data after sending ~15/hour for a few hours

Dramatically decreasing to limit potential rate limiting on Roborock's side and increase the chance of us automatically recovering.