### PR TITLE
feat: raise no account error when bad login

### DIFF
--- a/roborock/web_api.py
+++ b/roborock/web_api.py
@@ -361,7 +361,7 @@ class RoborockApiClient:
                 )
             if response_code == 3039:
                 raise RoborockAccountDoesNotExist(
-                    "This code does not exists - please ensure that you selected the right region and email."
+                    "This account does not exist - please ensure that you selected the right region and email."
                 )
             raise RoborockException(f"{login_response.get('msg')} - response code: {response_code}")
         user_data = login_response.get("data")


### PR DESCRIPTION
If a email does not exist for a given region - it will request the code and fail on login. This way we are raising a proper exception that can be checked and turned into human readable explanation