### PR TITLE
fix: handle different error format for map status

### DIFF
--- a/roborock/devices/traits/v1/common.py
+++ b/roborock/devices/traits/v1/common.py
@@ -9,27 +9,12 @@ from dataclasses import dataclass, fields
 from typing import ClassVar, Self
 
 from roborock.data import RoborockBase
-from roborock.exceptions import RoborockException
 from roborock.protocols.v1_protocol import V1RpcChannel
 from roborock.roborock_typing import RoborockCommand
 
 _LOGGER = logging.getLogger(__name__)
 
 V1ResponseData = dict | list | int | str
-
-
-def extract_v1_api_error_code(err: RoborockException) -> int | None:
-    """Extract a V1 RPC API error code from a RoborockException, if present.
-
-    V1 RPC error responses typically look like: {"code": -10007, "message": "..."}.
-    """
-    if not err.args:
-        return None
-    payload = err.args[0]
-    if isinstance(payload, dict):
-        code = payload.get("code")
-        return code if isinstance(code, int) else None
-    return None
 
 
 @dataclass

--- a/roborock/exceptions.py
+++ b/roborock/exceptions.py
@@ -87,5 +87,9 @@ class RoborockDeviceBusy(RoborockException):
     """Class for Roborock device busy exceptions."""
 
 
+class RoborockInvalidStatus(RoborockException):
+    """Class for Roborock invalid status exceptions (device action locked)."""
+
+
 class RoborockUnsupportedFeature(RoborockException):
     """Class for Roborock unsupported feature exceptions."""

--- a/tests/devices/traits/v1/test_home.py
+++ b/tests/devices/traits/v1/test_home.py
@@ -15,7 +15,7 @@ from roborock.devices.traits.v1.map_content import MapContentTrait
 from roborock.devices.traits.v1.maps import MapsTrait
 from roborock.devices.traits.v1.rooms import RoomsTrait
 from roborock.devices.traits.v1.status import StatusTrait
-from roborock.exceptions import RoborockDeviceBusy, RoborockException
+from roborock.exceptions import RoborockDeviceBusy, RoborockException, RoborockInvalidStatus
 from roborock.map.map_parser import ParsedMapData
 from roborock.roborock_typing import RoborockCommand
 from tests import mock_data
@@ -550,7 +550,7 @@ async def test_refresh_falls_back_when_map_switch_action_locked(
     # Discovery attempt: we can list maps, but switching maps fails with -10007.
     mock_mqtt_rpc_channel.send_command.side_effect = [
         MULTI_MAP_LIST_DATA,  # Maps refresh during discover_home()
-        RoborockException({"code": -10007, "message": "invalid status"}),  # LOAD_MULTI_MAP action locked
+        RoborockInvalidStatus({"code": -10007, "message": "invalid status"}),  # LOAD_MULTI_MAP action locked
         MULTI_MAP_LIST_DATA,  # Maps refresh during refresh() fallback
     ]
 


### PR DESCRIPTION
Relates to #160952

error format seemingly is different for some api/ some firmware. This allows us to handle it better and successfully return a apropriate exception on the map logic.