### PR TITLE
feat: add the ability to set q7 mode

### DIFF
--- a/roborock/data/b01_q7/b01_q7_containers.py
+++ b/roborock/data/b01_q7/b01_q7_containers.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass, field
 from ..containers import RoborockBase
 from .b01_q7_code_mappings import (
     B01Fault,
+    CleanTypeMapping,
     SCWindMapping,
+    WaterLevelMapping,
     WorkModeMapping,
     WorkStatusMapping,
 )
@@ -77,8 +79,8 @@ class B01Props(RoborockBase):
     status: WorkStatusMapping | None = None
     fault: B01Fault | None = None
     wind: SCWindMapping | None = None
-    water: int | None = None
-    mode: int | None = None
+    water: WaterLevelMapping | None = None
+    mode: CleanTypeMapping | None = None
     quantity: int | None = None
     alarm: int | None = None
     volume: int | None = None

--- a/roborock/devices/traits/b01/q7/__init__.py
+++ b/roborock/devices/traits/b01/q7/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 from roborock import B01Props
 from roborock.data.b01_q7.b01_q7_code_mappings import (
     CleanTaskTypeMapping,
+    CleanTypeMapping,
     SCDeviceCleanParam,
     SCWindMapping,
     WaterLevelMapping,
@@ -53,6 +54,10 @@ class Q7PropertiesApi(Trait):
     async def set_water_level(self, water_level: WaterLevelMapping) -> None:
         """Set the water level (water)."""
         await self.set_prop(RoborockB01Props.WATER, water_level.code)
+
+    async def set_mode(self, mode: CleanTypeMapping) -> None:
+        """Set the cleaning mode (vacuum, mop, or vacuum and mop)."""
+        await self.set_prop(RoborockB01Props.MODE, mode.code)
 
     async def start_clean(self) -> None:
         """Start cleaning."""


### PR DESCRIPTION
Q7 mode is interesting and a bit different than V1. You must explicitly set what mode you want to be in otherwise it will not work. You can change the mop mode while in vacuum mode, but it wont actually mop unless you change the mode.


Relates: #739