### PR TITLE
q7: narrow decoded command response type

### DIFF
--- a/roborock/devices/rpc/b01_q7_channel.py
+++ b/roborock/devices/rpc/b01_q7_channel.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import TypeAlias, TypeVar
 
 from roborock.devices.transport.mqtt_channel import MqttChannel
 from roborock.exceptions import RoborockException
@@ -16,6 +16,7 @@ from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
 _LOGGER = logging.getLogger(__name__)
 _TIMEOUT = 10.0
 _T = TypeVar("_T")
+DecodedB01Response: TypeAlias = dict[str, object] | str
 
 
 def _matches_map_response(response_message: RoborockMessage, *, version: bytes | None) -> bytes | None:
@@ -61,11 +62,11 @@ async def _send_command(
 async def send_decoded_command(
     mqtt_channel: MqttChannel,
     request_message: Q7RequestMessage,
-) -> Any:
+) -> DecodedB01Response:
     """Send a command on the MQTT channel and get a decoded response."""
     _LOGGER.debug("Sending B01 MQTT command: %s", request_message)
 
-    def find_response(response_message: RoborockMessage) -> Any | None:
+    def find_response(response_message: RoborockMessage) -> DecodedB01Response | None:
         """Handle incoming messages and resolve the future."""
         try:
             decoded_dps = decode_rpc_response(response_message)


### PR DESCRIPTION
Openclaw (AI): Follow-up to #778 for Allen's final post-merge typing/style nit.

This keeps the existing B01 behavior but narrows `send_decoded_command()` away from `Any` to a concrete response alias:

`DecodedB01Response = dict[str, object] | str`

Why each type exists:
- `dict[str, object]`: used for decoded query-style responses where `data` is structured content, e.g. `prop.get`, `service.get_map_list`, and other read/query helpers that parse fields from the returned payload.
- `str`: used for raw command ACK responses where the device returns a plain success token like `"ok"`, e.g. action-style commands such as clean/start/pause/stop flows that only need acknowledgement rather than structured data.

The point of this follow-up is to make the return shape more explicit for callers/reviewers without over-constraining it to `dict` and regressing the existing ACK path.

Validation:
- `./.venv/bin/pytest -q tests/devices/traits/b01/q7/test_init.py`
- `ruff check roborock/devices/rpc/b01_q7_channel.py tests/devices/traits/b01/q7/test_init.py`
