### PR TITLE
Fix/q10-fault-vacuum-error

### DIFF
--- a/roborock/data/b01_q10/b01_q10_containers.py
+++ b/roborock/data/b01_q10/b01_q10_containers.py
@@ -107,3 +107,4 @@ class Q10Status(RoborockBase):
     clean_task_type: YXDeviceCleanTask | None = field(default=None, metadata={"dps": B01_Q10_DP.CLEAN_TASK_TYPE})
     back_type: YXBackType | None = field(default=None, metadata={"dps": B01_Q10_DP.BACK_TYPE})
     cleaning_progress: int | None = field(default=None, metadata={"dps": B01_Q10_DP.CLEAN_PROGRESS})
+    fault: int | None = field(default=None, metadata={"dps": B01_Q10_DP.FAULT})

--- a/tests/devices/traits/b01/q10/test_status.py
+++ b/tests/devices/traits/b01/q10/test_status.py
@@ -115,6 +115,7 @@ async def test_status_trait_refresh(
     assert q10_api.status.total_clean_count is None
     assert q10_api.status.main_brush_life is None
     assert q10_api.status.cleaning_progress is None
+    assert q10_api.status.fault is None
 
     # Mock the response to refresh
     # battery (122) = 100
@@ -151,6 +152,7 @@ async def test_status_trait_refresh(
     assert q10_api.status.filter_life == 0
     assert q10_api.status.sensor_life == 0
     assert q10_api.status.cleaning_progress == 100
+    assert q10_api.status.fault == 0
 
 
 def test_status_trait_update_listener(q10_api: Q10PropertiesApi) -> None:


### PR DESCRIPTION
- Added the missing `fault` field to `Q10Status` in `python-roborock`, mapped to `B01_Q10_DP.FAULT` (`dpFault`, DPS `90`).
- Extended Q10 status trait tests to assert `fault` is present and correctly parsed during refresh.
