### PR TITLE
feat(api)!: Again rename `YXDeviceState` enum members to have consistency with V1 state values

### DIFF
--- a/roborock/data/b01_q10/b01_q10_code_mappings.py
+++ b/roborock/data/b01_q10/b01_q10_code_mappings.py
@@ -164,24 +164,24 @@ class YXCleanType(RoborockModeEnum):
 
 class YXDeviceState(RoborockModeEnum):
     UNKNOWN = "unknown", -1
-    SLEEP_STATE = "sleeping", 2
-    STANDBY_STATE = "standby", 3
-    CLEANING_STATE = "cleaning", 5
-    TO_CHARGE_STATE = "going_to_charge", 6
-    REMOTEING_STATE = "remote_control", 7
-    CHARGING_STATE = "charging", 8
-    PAUSE_STATE = "paused", 10
-    FAULT_STATE = "fault", 12
-    UPGRADE_STATE = "updating", 14
-    DUSTING = "dusting", 22
-    CREATING_MAP_STATE = "creating_map", 29
-    MAP_SAVE_STATE = "saving_map", 99
-    RE_LOCATION_STATE = "relocating", 101
-    ROBOT_SWEEPING = "sweeping", 102
-    ROBOT_MOPING = "mopping", 103
-    ROBOT_SWEEP_AND_MOPING = "sweep_and_mop", 104
-    ROBOT_TRANSITIONING = "transitioning", 105
-    ROBOT_WAIT_CHARGE = "waiting_to_charge", 108
+    SLEEPING = "sleeping", 2  # sleepstate
+    IDLE = "idle", 3  # standbystate
+    CLEANING = "cleaning", 5  # cleaningstate
+    RETURNING_HOME = "returning_home", 6  # tochargestate
+    REMOTE_CONTROL_ACTIVE = "remote_control_active", 7  # remoteingstate
+    CHARGING = "charging", 8  # chargingstate
+    PAUSED = "paused", 10  # pausestate
+    ERROR = "error", 12  # faultstate
+    UPDATING = "updating", 14  # upgradestate
+    EMPTYING_THE_BIN = "emptying_the_bin", 22  # dusting
+    MAPPING = "mapping", 29  # creatingmapstate
+    SAVING_MAP = "saving_map", 99  # mapsavestate
+    RELOCATING = "relocating", 101  # relocationstate
+    SWEEPING = "sweeping", 102  # robotsweeping
+    MOPPING = "mopping", 103  # robotmoping
+    SWEEP_AND_MOP = "sweep_and_mop", 104  # robotsweepandmoping
+    TRANSITIONING = "transitioning", 105  # robottransitioning
+    WAITING_TO_CHARGE = "waiting_to_charge", 108  # robotwaitcharge
 
 
 class YXBackType(RoborockModeEnum):

--- a/tests/data/b01_q10/test_b01_q10_code_mappings.py
+++ b/tests/data/b01_q10/test_b01_q10_code_mappings.py
@@ -1,38 +1,35 @@
 """Test cases for B01 Q10 code mappings."""
 
+import pytest
+
 from roborock.data.b01_q10 import YXDeviceState
 
 
-def test_q10_status_values_are_canonical() -> None:
+@pytest.mark.parametrize(
+    "state, string",
+    [
+        (YXDeviceState.UNKNOWN, "unknown"),
+        (YXDeviceState.IDLE, "idle"),
+        (YXDeviceState.CHARGING, "charging"),
+        (YXDeviceState.CLEANING, "cleaning"),
+        (YXDeviceState.SLEEPING, "sleeping"),
+        (YXDeviceState.UPDATING, "updating"),
+        (YXDeviceState.RETURNING_HOME, "returning_home"),
+    ],
+)
+def test_q10_status_values_are_canonical(state: YXDeviceState, string: str) -> None:
     """Q10 status enum values should expose canonical names."""
-    expected_values = {
-        YXDeviceState.UNKNOWN: "unknown",
-        YXDeviceState.SLEEP_STATE: "sleeping",
-        YXDeviceState.STANDBY_STATE: "standby",
-        YXDeviceState.CLEANING_STATE: "cleaning",
-        YXDeviceState.TO_CHARGE_STATE: "going_to_charge",
-        YXDeviceState.REMOTEING_STATE: "remote_control",
-        YXDeviceState.CHARGING_STATE: "charging",
-        YXDeviceState.PAUSE_STATE: "paused",
-        YXDeviceState.FAULT_STATE: "fault",
-        YXDeviceState.UPGRADE_STATE: "updating",
-        YXDeviceState.DUSTING: "dusting",
-        YXDeviceState.CREATING_MAP_STATE: "creating_map",
-        YXDeviceState.MAP_SAVE_STATE: "saving_map",
-        YXDeviceState.RE_LOCATION_STATE: "relocating",
-        YXDeviceState.ROBOT_SWEEPING: "sweeping",
-        YXDeviceState.ROBOT_MOPING: "mopping",
-        YXDeviceState.ROBOT_SWEEP_AND_MOPING: "sweep_and_mop",
-        YXDeviceState.ROBOT_TRANSITIONING: "transitioning",
-        YXDeviceState.ROBOT_WAIT_CHARGE: "waiting_to_charge",
-    }
-
-    assert {state: state.value for state in expected_values} == expected_values
-    assert all(not value.endswith("state") for value in expected_values.values())
+    assert state.value == string
 
 
-def test_q10_status_codes_map_to_canonical_values() -> None:
+@pytest.mark.parametrize(
+    "code, expected_state",
+    [
+        (5, YXDeviceState.CLEANING),
+        (8, YXDeviceState.CHARGING),
+        (14, YXDeviceState.UPDATING),
+    ],
+)
+def test_q10_status_codes_map_to_canonical_values(code: int, expected_state: YXDeviceState) -> None:
     """Code-based mapping should return canonical status values."""
-    assert YXDeviceState.from_code(5) is YXDeviceState.CLEANING_STATE
-    assert YXDeviceState.from_code(8) is YXDeviceState.CHARGING_STATE
-    assert YXDeviceState.from_code(14) is YXDeviceState.UPGRADE_STATE
+    assert YXDeviceState.from_code(code) is expected_state

--- a/tests/devices/traits/b01/q10/test_status.py
+++ b/tests/devices/traits/b01/q10/test_status.py
@@ -96,10 +96,10 @@ async def test_status_trait_streaming(
     message_queue.put_nowait(message)
 
     # Wait for the update
-    await wait_for_attribute_value(q10_api.status, "status", YXDeviceState.CHARGING_STATE)
+    await wait_for_attribute_value(q10_api.status, "status", YXDeviceState.CHARGING)
 
     # Verify trait attributes are updated
-    assert q10_api.status.status == YXDeviceState.CHARGING_STATE
+    assert q10_api.status.status == YXDeviceState.CHARGING
     assert q10_api.status.clean_task_type == YXDeviceCleanTask.IDLE
 
 
@@ -142,7 +142,7 @@ async def test_status_trait_refresh(
 
     # Verify trait attributes are updated
     assert q10_api.status.battery == 100
-    assert q10_api.status.status == YXDeviceState.CHARGING_STATE
+    assert q10_api.status.status == YXDeviceState.CHARGING
     assert q10_api.status.fan_level == YXFanLevel.BALANCED
     assert q10_api.status.total_clean_area == 0
     assert q10_api.status.total_clean_count == 0


### PR DESCRIPTION
The motivation is to not have entirely different state values for the same concept to make it easier to write systems that can handle each device.