### PR TITLE
feat(api)!: rename `YXWaterLevel` enum values to mirror v1 values

### DIFF
--- a/roborock/data/b01_q10/b01_q10_code_mappings.py
+++ b/roborock/data/b01_q10/b01_q10_code_mappings.py
@@ -136,9 +136,9 @@ class YXFanLevel(RoborockModeEnum):
 
 class YXWaterLevel(RoborockModeEnum):
     UNKNOWN = "unknown", -1
-    CLOSE = "close", 0
+    OFF = "off", 0  # close
     LOW = "low", 1
-    MIDDLE = "middle", 2
+    MEDIUM = "medium", 2  # middle
     HIGH = "high", 3
 
 

--- a/tests/protocols/test_b01_q10_protocol.py
+++ b/tests/protocols/test_b01_q10_protocol.py
@@ -97,7 +97,7 @@ def test_decode_unknown_dps_code() -> None:
         (B01_Q10_DP.REQUEST_DPS, {}),
         (B01_Q10_DP.REQUEST_DPS, None),
         (B01_Q10_DP.START_CLEAN, {"cmd": 1}),
-        (B01_Q10_DP.WATER_LEVEL, YXWaterLevel.MIDDLE.code),
+        (B01_Q10_DP.WATER_LEVEL, YXWaterLevel.MEDIUM.code),
     ],
 )
 def test_encode_mqtt_payload(command: B01_Q10_DP, params: dict[str, Any], snapshot) -> None:


### PR DESCRIPTION
This is a small change to make the enum values slightly more consistent to make it easier to interpret q10 and v1 devices with similar state values where possible.