### PR TITLE
fix: allow protobuf 7.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pycryptodomex~=3.18 ; sys_platform == 'darwin'",
     "paho-mqtt>=1.6.1,<3.0.0",
     "construct>=2.10.57,<3",
-    "protobuf>=6.31.1,<7",
+    "protobuf>=6.31.1,<8",
     "vacuum-map-parser-roborock",
     "pyrate-limiter>=4.0.0,<5",
     "aiomqtt>=2.5.0,<3",


### PR DESCRIPTION
Widens the protobuf upper bound so downstream projects can use protobuf 7 alongside python-roborock; the generated pb2 modules remain compatible with the 7.x runtime per the protobuf cross version policy.

Home Assistant is bumping to protobuf 7.34.1 and currently cannot resolve dependencies against python-roborock 5.x; see https://github.com/home-assistant/core/pull/168811.