### PR TITLE
fix: operator precedence bug with walrus operator in cli.py command ex…

### DIFF
--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -780,7 +780,7 @@ async def command(ctx, cmd, device_id, params):
         if result:
             click.echo(dump_json(result))
     elif device.b01_q10_properties is not None:
-        if cmd_value := B01_Q10_DP.from_any_optional(cmd) is None:
+        if (cmd_value := B01_Q10_DP.from_any_optional(cmd)) is None:
             raise RoborockException(f"Invalid command {cmd} for B01_Q10 device")
         command_trait: Trait = device.b01_q10_properties.command
         await command_trait.send(cmd_value, json.loads(params) if params is not None else None)


### PR DESCRIPTION
…ecution

## Description
There is a critical operator precedence bug in the `command` function inside `roborock/cli.py` affecting `B01_Q10` devices (and potentially others using the same logic).

Currently, the code reads:
`if cmd_value := B01_Q10_DP.from_any_optional(cmd) is None:`

Because the `is` operator binds tighter than the walrus operator (`:=`), Python evaluates `(B01_Q10_DP.from_any_optional(cmd) is None)` first.  If a valid command is passed, this evaluates to `False`, and the boolean `False` is assigned to `cmd_value`. The `if` block is then skipped, and `cmd_value` (`False`) is passed to `command_trait.send()`.

This results in a crash shortly after:
`AttributeError: 'bool' object has no attribute 'code'`

## Fix
Adding parentheses around the assignment expression fixes the evaluation order: `if (cmd_value := B01_Q10_DP.from_any_optional(cmd)) is None:`