### PR TITLE
fix: mark non vacuum v1 devices as not supported

### DIFF
--- a/roborock/devices/device_manager.py
+++ b/roborock/devices/device_manager.py
@@ -13,6 +13,7 @@ from roborock.data import (
     HomeData,
     HomeDataDevice,
     HomeDataProduct,
+    RoborockCategory,
     UserData,
 )
 from roborock.devices.device import DeviceReadyCallback, RoborockDevice
@@ -228,6 +229,10 @@ async def create_device_manager(
         device_cache: DeviceCache = DeviceCache(device.duid, cache)
         match device.pv:
             case DeviceVersion.V1:
+                if product.category != RoborockCategory.VACUUM:
+                    raise UnsupportedDeviceError(
+                        f"Device {device.name} has unsupported V1 category {product.category}: {product.model}"
+                    )
                 channel = create_v1_channel(user_data, mqtt_params, mqtt_session, device, device_cache)
                 trait = v1.create(
                     device.duid,

--- a/tests/devices/test_device_manager.py
+++ b/tests/devices/test_device_manager.py
@@ -420,3 +420,55 @@ async def test_unsupported_protocol_version() -> None:
         assert diagnostics_data
         assert diagnostics_data.get("supported_devices") == {"1.0": 1}
         assert diagnostics_data.get("unsupported_devices") == {"unknown-pv": 1}
+
+
+async def test_unsupported_v1_category() -> None:
+    """Test that non-vacuum V1 devices are skipped as unsupported."""
+    with patch("roborock.devices.device_manager.UserWebApiClient.get_home_data") as mock_home_data:
+        home_data = HomeData.from_dict(
+            {
+                "id": 1,
+                "name": "Test Home",
+                "devices": [
+                    {
+                        "duid": "device-uid-1",
+                        "name": "Device 1",
+                        "pv": "1.0",
+                        "productId": "product-id-1",
+                        "localKey": mock_data.LOCAL_KEY,
+                    },
+                    {
+                        "duid": "device-uid-2",
+                        "name": "Device 2",
+                        "pv": "1.0",
+                        "productId": "product-id-2",
+                        "localKey": mock_data.LOCAL_KEY,
+                    },
+                ],
+                "products": [
+                    {
+                        "id": "product-id-1",
+                        "name": "Roborock S7 MaxV",
+                        "model": "roborock.vacuum.a27",
+                        "category": "robot.vacuum.cleaner",
+                    },
+                    {
+                        "id": "product-id-2",
+                        "name": "Roborock RockNeo",
+                        "model": "roborock.mower.q105",
+                        "category": "roborock.mower",
+                    },
+                ],
+            }
+        )
+        mock_home_data.return_value = home_data
+
+        device_manager = await create_device_manager(USER_PARAMS)
+        devices = await device_manager.get_devices()
+        assert [device.duid for device in devices] == ["device-uid-1"]
+
+        diagnostics = device_manager.diagnostic_data()
+        diagnostics_data = diagnostics.get("diagnostics")
+        assert diagnostics_data
+        assert diagnostics_data.get("supported_devices") == {"1.0": 1}
+        assert diagnostics_data.get("unsupported_devices") == {"1.0": 1}


### PR DESCRIPTION
should handle https://github.com/home-assistant/core/issues/167674