### PR TITLE
feat: add Qrevo S5V dock type code (22) to RoborockDockTypeCode

### DIFF
--- a/roborock/data/v1/v1_code_mappings.py
+++ b/roborock/data/v1/v1_code_mappings.py
@@ -664,6 +664,7 @@ class RoborockDockTypeCode(RoborockEnum):
     saros_r10_dock = 16
     qrevo_curv_dock = 17
     saros_10_dock = 18
+    qrevo_s5v_dock = 22
 
 
 class RoborockDockDustCollectionModeCode(RoborockEnum):

--- a/roborock/device_features.py
+++ b/roborock/device_features.py
@@ -653,6 +653,7 @@ WASH_N_FILL_DOCK_TYPES = [
     RoborockDockTypeCode.qrevo_s_dock,
     RoborockDockTypeCode.saros_r10_dock,
     RoborockDockTypeCode.qrevo_curv_dock,
+    RoborockDockTypeCode.qrevo_s5v_dock,
 ]
 
 

--- a/tests/data/v1/test_v1_containers.py
+++ b/tests/data/v1/test_v1_containers.py
@@ -263,6 +263,15 @@ def test_no_value():
     assert "missing" not in RoborockDockTypeCode.values()
 
 
+def test_qrevo_s5v_dock_type():
+    """Test that dock type code 22 (Qrevo S5V dock) is properly recognized."""
+    modified_status = STATUS.copy()
+    modified_status["dock_type"] = 22
+    s = S7MaxVStatus.from_dict(modified_status)
+    assert s.dock_type == RoborockDockTypeCode.qrevo_s5v_dock
+    assert s.dock_type.value == 22
+
+
 def test_multi_maps_list_info(snapshot: SnapshotAssertion) -> None:
     """Test that MultiMapsListInfo can be deserialized correctly."""
     data = {

--- a/tests/devices/traits/v1/test_dust_collection_mode.py
+++ b/tests/devices/traits/v1/test_dust_collection_mode.py
@@ -29,6 +29,7 @@ def dust_collection_mode_trait(
         (RoborockDockTypeCode.s8_dock),
         (RoborockDockTypeCode.p10_dock),
         (RoborockDockTypeCode.qrevo_s_dock),
+        (RoborockDockTypeCode.qrevo_s5v_dock),
     ],
 )
 async def test_dust_collection_mode_available(

--- a/tests/devices/traits/v1/test_smart_wash_params.py
+++ b/tests/devices/traits/v1/test_smart_wash_params.py
@@ -30,6 +30,7 @@ def smart_wash_params_trait(
         (RoborockDockTypeCode.s8_dock),
         (RoborockDockTypeCode.p10_dock),
         (RoborockDockTypeCode.qrevo_s_dock),
+        (RoborockDockTypeCode.qrevo_s5v_dock),
     ],
 )
 async def test_smart_wash_available(

--- a/tests/devices/traits/v1/test_wash_towel_mode.py
+++ b/tests/devices/traits/v1/test_wash_towel_mode.py
@@ -31,6 +31,7 @@ def wash_towel_mode_trait(
         (RoborockDockTypeCode.s8_dock),
         (RoborockDockTypeCode.p10_dock),
         (RoborockDockTypeCode.qrevo_s_dock),
+        (RoborockDockTypeCode.qrevo_s5v_dock),
     ],
 )
 async def test_wash_towel_mode_available(


### PR DESCRIPTION
## Summary

- Add `qrevo_s5v_dock` (code 22) to `RoborockDockTypeCode` enum in `v1_code_mappings.py`
- Add the new dock type to `WASH_N_FILL_DOCK_TYPES` in `device_features.py` since the Qrevo S5V dock is a wash-and-fill dock
- Add test coverage for the new dock type code

## Context

The Roborock Qrevo S5V vacuum dock reports dock type code **22**, which was not previously defined in the library. This caused a warning log on every Home Assistant startup:

```
Missing RoborockDockTypeCode code: 22 - defaulting to 'unknown'
```

While the `_missing_` method gracefully falls back to `unknown`, this clutters logs and means the dock type isn't properly identified. The Qrevo S5V is a 2025 model with a multi-function wash dock (same dock family as the Qrevo Curv, code 17).

## Changes

| File | Change |
|------|--------|
| `roborock/data/v1/v1_code_mappings.py` | Added `qrevo_s5v_dock = 22` |
| `roborock/device_features.py` | Added to `WASH_N_FILL_DOCK_TYPES` list |
| `tests/data/v1/test_v1_containers.py` | Added test for code 22 recognition |
| `tests/devices/traits/v1/test_wash_towel_mode.py` | Added qrevo_s5v_dock to parametrized tests |
| `tests/devices/traits/v1/test_dust_collection_mode.py` | Added qrevo_s5v_dock to parametrized tests |
| `tests/devices/traits/v1/test_smart_wash_params.py` | Added qrevo_s5v_dock to parametrized tests |

All 56 affected tests pass.