### PR TITLE
fix: wrap aiohttp network errors in RoborockException

### DIFF
--- a/roborock/web_api.py
+++ b/roborock/web_api.py
@@ -692,6 +692,8 @@ class PreparedRequest:
             _LOGGER.info("Resp raw: %s", resp_raw)
             # Still raise the err so that it's clear it failed.
             raise err
+        except (aiohttp.ClientError, TimeoutError, OSError) as err:
+            raise RoborockException(f"Network error contacting {_url}: {err}") from err
         finally:
             if close_session:
                 await session.close()

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -7,8 +7,8 @@ import pytest
 from aioresponses.compat import normalize_url
 
 from roborock import HomeData, HomeDataScene, UserData
-from roborock.exceptions import RoborockAccountDoesNotExist, RoborockInvalidCredentials
-from roborock.web_api import IotLoginInfo, RoborockApiClient, UserWebApiClient
+from roborock.exceptions import RoborockAccountDoesNotExist, RoborockException, RoborockInvalidCredentials
+from roborock.web_api import IotLoginInfo, PreparedRequest, RoborockApiClient, UserWebApiClient
 from tests.mock_data import HOME_DATA_RAW, USER_DATA
 
 pytest_plugins = [
@@ -398,3 +398,24 @@ async def test_user_web_api_client_unauthorized_hook() -> None:
     with pytest.raises(RoborockInvalidCredentials):
         await client.get_rooms()
     mock_hook.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        aiohttp.ClientError("connection failed"),
+        TimeoutError("timed out"),
+        OSError("dns failure"),
+    ],
+    ids=["client_error", "timeout", "os_error"],
+)
+async def test_prepared_request_wraps_network_errors(exception: Exception, mock_rest: Any) -> None:
+    """Network errors from aiohttp must be wrapped as RoborockException so
+    consumers can rely on the typed exception hierarchy."""
+    url_pattern = re.compile(r"https://example\.com/api/test.*")
+    mock_rest.post(url_pattern, exception=exception)
+
+    req = PreparedRequest("https://example.com")
+    with pytest.raises(RoborockException) as exc_info:
+        await req.request("post", "/api/test")
+    assert exc_info.value.__cause__ is exception


### PR DESCRIPTION
## Summary

Network-class exceptions raised inside `PreparedRequest.request` (`aiohttp.ClientError`, `TimeoutError`, `OSError`) were bubbling out unwrapped, bypassing consumers that catch `RoborockException`.

## Real-world impact

This caused Home Assistant's roborock integration to mark config entries as terminally failed after a power outage when DNS hadn't resolved yet — requiring the user to manually restart HA to recover. A defensive catch was added in HA core (home-assistant/core#172492) as a temporary workaround, but the root fix belongs here.

The HA codeowner [@allenporter explicitly asked][allenporter-comment] for the upstream fix and for the HA-side workaround to be reverted after this lands.

[allenporter-comment]: https://github.com/home-assistant/core/pull/172492#issuecomment-4576280978

## What's changed

`PreparedRequest.request` (`web_api.py`) is the single chokepoint that every HTTP call in `RoborockApiClient` / `UserWebApiClient` routes through. This PR adds a single except clause there:

```python
except (aiohttp.ClientError, TimeoutError, OSError) as err:
    raise RoborockException(f"Network error contacting {_url}: {err}") from err
```

Every API method (`get_home_data`, `request_code`, `pass_login`, `nc_prepare`, `add_device`, etc.) automatically benefits.

The original exception is preserved via `__cause__` for debuggability.

## What's NOT changed

- `ContentTypeError` handling is unchanged — that path is still re-raised as-is for callers that want response-shape debugging.
- MQTT session setup is a separate code path that may have a similar leak. Not addressed here to keep this PR focused; happy to do as a follow-up.

## Tests

Added `tests/test_web_api.py::test_prepared_request_wraps_network_errors` — parametrized over `aiohttp.ClientError`, `TimeoutError`, `OSError` — asserts the exception is wrapped as `RoborockException` with the original preserved as `__cause__`. Full suite passes locally (486 tests, no regressions). Ruff format + check clean; mypy clean.

## Follow-up

After this merges and a new python-roborock release is cut, I'll open a PR against `home-assistant/core` that bumps the dep AND reverts the HA-side workaround in 172492.