### PR TITLE
q10: accept customized clean mode code 4

### DIFF
--- a/roborock/data/b01_q10/b01_q10_code_mappings.py
+++ b/roborock/data/b01_q10/b01_q10_code_mappings.py
@@ -162,7 +162,7 @@ class YXCleanType(RoborockModeEnum):
     VAC_AND_MOP = "vac_and_mop", 1  # bothwork
     VACUUM = "vacuum", 2  # onlysweep
     MOP = "mop", 3  # onlymop
-    CUSTOMIZED = "customized", 4
+    CUSTOMIZED = "customized", 4  # custom mode
 
 
 class YXDeviceState(RoborockModeEnum):

--- a/roborock/data/b01_q10/b01_q10_code_mappings.py
+++ b/roborock/data/b01_q10/b01_q10_code_mappings.py
@@ -162,6 +162,7 @@ class YXCleanType(RoborockModeEnum):
     VAC_AND_MOP = "vac_and_mop", 1  # bothwork
     VACUUM = "vacuum", 2  # onlysweep
     MOP = "mop", 3  # onlymop
+    CUSTOMIZED = "customized", 4
 
 
 class YXDeviceState(RoborockModeEnum):

--- a/tests/data/test_code_mappings.py
+++ b/tests/data/test_code_mappings.py
@@ -97,9 +97,15 @@ def test_homedata_product_unknown_category():
         ("vac_and_mop", YXCleanType.VAC_AND_MOP),
         ("vacuum", YXCleanType.VACUUM),
         ("mop", YXCleanType.MOP),
+        ("customized", YXCleanType.CUSTOMIZED),
     ],
 )
 def test_yx_clean_type_from_value_readable_values(readable_value: str, expected_clean_type: YXCleanType) -> None:
     """Test YXCleanType accepts canonical readable values."""
     assert YXCleanType.from_value(readable_value) is expected_clean_type
     assert expected_clean_type.value == readable_value
+
+
+def test_yx_clean_type_from_code_customized() -> None:
+    """Test YXCleanType accepts custom mode code used by Q10 status updates."""
+    assert YXCleanType.from_code(4) is YXCleanType.CUSTOMIZED


### PR DESCRIPTION
## Summary

This change fixes Q10 status parsing for custom cleaning mode.

### What was done
- Added support for clean mode code 4 in the Q10 clean mode enum by introducing the CUSTOMIZED value.
- Added/updated unit tests to verify:
  - Parsing from readable value customized
  - Parsing from numeric code 4

### Why this was needed
- Q10 devices can report dpCleanMode = 4 during room-based/customized cleaning.
- Without this enum value, parsing raised a ValueError and produced conversion errors in logs.
