### PR TITLE
feat(q7): add set_volume trait method

### DIFF
--- a/roborock/devices/traits/b01/q7/__init__.py
+++ b/roborock/devices/traits/b01/q7/__init__.py
@@ -108,6 +108,10 @@ class Q7PropertiesApi(Trait):
         """Set the cleaning repeat state (cycles)."""
         await self.set_prop(RoborockB01Props.REPEAT_STATE, repeat.code)
 
+    async def set_volume(self, volume: int) -> None:
+        """Set the robot voice volume (0-100)."""
+        await self.set_prop(RoborockB01Props.VOLUME, volume)
+
     async def start_clean(self) -> None:
         """Start cleaning."""
         await self.send(

--- a/tests/devices/traits/b01/q7/test_init.py
+++ b/tests/devices/traits/b01/q7/test_init.py
@@ -152,6 +152,24 @@ async def test_q7_api_set_water_level(
     assert payload_data["dps"]["10000"]["params"] == {RoborockB01Props.WATER: WaterLevelMapping.HIGH.code}
 
 
+@pytest.mark.parametrize("volume", [0, 50, 100])
+async def test_q7_api_set_volume(
+    volume: int,
+    q7_api: Q7PropertiesApi,
+    fake_channel: FakeChannel,
+    message_builder: B01MessageBuilder,
+):
+    """Test setting the robot voice volume."""
+    fake_channel.response_queue.append(message_builder.build({"result": "ok"}))
+    await q7_api.set_volume(volume)
+
+    assert len(fake_channel.published_messages) == 1
+    message = fake_channel.published_messages[0]
+    payload_data = json.loads(unpad(message.payload, AES.block_size))
+    assert payload_data["dps"]["10000"]["method"] == "prop.set"
+    assert payload_data["dps"]["10000"]["params"] == {RoborockB01Props.VOLUME: volume}
+
+
 @pytest.mark.parametrize(
     ("mode", "expected_code"),
     [


### PR DESCRIPTION
## Summary

Adds `set_volume(volume)` to the Q7 (B01) trait, sending `prop.set` for
`RoborockB01Props.VOLUME`. Part of #739.

Voice volume range is **0-100**, confirmed device-exactly (default `100`).

## Verification

- Getter + setter verified live on a Roborock Q7 L5+ via raw protocol capture.
- New parametrized unit test (0 / 50 / 100); `ruff` clean.
