### PR TITLE
feat(q7): add set_child_lock trait method

### DIFF
--- a/roborock/devices/traits/b01/q7/__init__.py
+++ b/roborock/devices/traits/b01/q7/__init__.py
@@ -112,6 +112,10 @@ class Q7PropertiesApi(Trait):
         """Set the robot voice volume (0-100)."""
         await self.set_prop(RoborockB01Props.VOLUME, volume)
 
+    async def set_child_lock(self, enabled: bool) -> None:
+        """Enable or disable the child lock."""
+        await self.set_prop(RoborockB01Props.CHILD_LOCK, int(enabled))
+
     async def start_clean(self) -> None:
         """Start cleaning."""
         await self.send(

--- a/tests/devices/traits/b01/q7/test_init.py
+++ b/tests/devices/traits/b01/q7/test_init.py
@@ -171,6 +171,28 @@ async def test_q7_api_set_volume(
 
 
 @pytest.mark.parametrize(
+    ("enabled", "expected_code"),
+    [(True, 1), (False, 0)],
+)
+async def test_q7_api_set_child_lock(
+    enabled: bool,
+    expected_code: int,
+    q7_api: Q7PropertiesApi,
+    fake_channel: FakeChannel,
+    message_builder: B01MessageBuilder,
+):
+    """Test toggling the child lock."""
+    fake_channel.response_queue.append(message_builder.build({"result": "ok"}))
+    await q7_api.set_child_lock(enabled)
+
+    assert len(fake_channel.published_messages) == 1
+    message = fake_channel.published_messages[0]
+    payload_data = json.loads(unpad(message.payload, AES.block_size))
+    assert payload_data["dps"]["10000"]["method"] == "prop.set"
+    assert payload_data["dps"]["10000"]["params"] == {RoborockB01Props.CHILD_LOCK: expected_code}
+
+
+@pytest.mark.parametrize(
     ("mode", "expected_code"),
     [
         (CleanTypeMapping.VACUUM, 0),


### PR DESCRIPTION
## Summary

Adds `set_child_lock(enabled)` to the Q7 (B01) trait, sending `prop.set` for
`RoborockB01Props.CHILD_LOCK` (`0`/`1`). Part of #739.

## Verification

- Getter + setter verified live on a Roborock Q7 L5+.
- New parametrized unit test (on/off); `ruff` clean.
