### PR TITLE
fix(web_api): sign request body in Hawk auth for B01 /jobs writes

### DIFF
--- a/roborock/web_api.py
+++ b/roborock/web_api.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+import json
 import logging
 import math
 import secrets
@@ -646,6 +647,31 @@ class RoborockApiClient:
         else:
             raise RoborockException(f"schedule_response result was an unexpected type: {schedules}")
 
+    async def create_job(self, user_data: UserData, device_id: str, job: dict) -> dict:
+        """Create a /jobs entry (schedule or one-time room clean) on a B01 device.
+
+        Body-bearing writes must sign the request body in the Hawk payload slot and send those same
+        compact bytes via ``data=``; ``json=`` would re-serialize with spaces and break the MAC.
+        """
+        rriot = user_data.rriot
+        if rriot is None:
+            raise RoborockException("rriot is none")
+        if rriot.r.a is None:
+            raise RoborockException("Missing field 'a' in rriot reference")
+        path = f"/user/devices/{device_id}/jobs"
+        job_request = PreparedRequest(
+            rriot.r.a,
+            self.session,
+            {
+                "Authorization": _get_hawk_authentication(rriot, path, body=job),
+                "Content-Type": "application/json",
+            },
+        )
+        response = await job_request.request("post", path, data=_compact_json(job).encode())
+        if not response.get("success"):
+            raise RoborockException(response)
+        return response
+
     async def get_products(self, user_data: UserData) -> ProductResponse:
         """Gets all products and their schemas, good for determining status codes and model numbers."""
         base_url = await self.base_url
@@ -738,11 +764,25 @@ def _process_extra_hawk_values(values: dict | None) -> str:
         return hashlib.md5("&".join(result).encode()).hexdigest()
 
 
-def _get_hawk_authentication(rriot: RRiot, url: str, formdata: dict | None = None, params: dict | None = None) -> str:
+def _compact_json(body: dict) -> str:
+    """Serialize a JSON body to the exact compact bytes that are both signed and sent."""
+    return json.dumps(body, separators=(",", ":"))
+
+
+def _get_hawk_authentication(
+    rriot: RRiot,
+    url: str,
+    formdata: dict | None = None,
+    params: dict | None = None,
+    body: dict | None = None,
+) -> str:
     timestamp = math.floor(time.time())
     nonce = secrets.token_urlsafe(6)
-    formdata_str = _process_extra_hawk_values(formdata)
     params_str = _process_extra_hawk_values(params)
+    if body is not None:
+        payload_str = hashlib.md5(_compact_json(body).encode()).hexdigest()
+    else:
+        payload_str = _process_extra_hawk_values(formdata)
 
     prestr = ":".join(
         [
@@ -752,7 +792,7 @@ def _get_hawk_authentication(rriot: RRiot, url: str, formdata: dict | None = Non
             str(timestamp),
             hashlib.md5(url.encode()).hexdigest(),
             params_str,
-            formdata_str,
+            payload_str,
         ]
     )
     mac = base64.b64encode(hmac.new(rriot.h.encode(), prestr.encode(), hashlib.sha256).digest()).decode()

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -8,7 +8,14 @@ from aioresponses.compat import normalize_url
 
 from roborock import HomeData, HomeDataRoom, HomeDataScene, UserData
 from roborock.exceptions import RoborockAccountDoesNotExist, RoborockException, RoborockInvalidCredentials
-from roborock.web_api import IotLoginInfo, PreparedRequest, RoborockApiClient, UserWebApiClient
+from roborock.web_api import (
+    IotLoginInfo,
+    PreparedRequest,
+    RoborockApiClient,
+    UserWebApiClient,
+    _compact_json,
+    _get_hawk_authentication,
+)
 from tests.mock_data import HOME_DATA_RAW, USER_DATA
 
 pytest_plugins = [
@@ -375,6 +382,42 @@ async def test_get_schedules(mock_rest) -> None:
     assert schedule.cron == "03 13 15 12 ?"
     assert schedule.repeated is False
     assert schedule.enabled is True
+
+
+async def test_create_job(mock_rest) -> None:
+    """A /jobs write (schedule or one-time clean) POSTs the body and returns the parsed result."""
+    api = RoborockApiClient(username="test_user@gmail.com")
+    ud = await api.pass_login("password")
+
+    mock_rest.post(
+        "https://api-us.roborock.com/user/devices/123456/jobs",
+        status=200,
+        payload={"api": None, "result": "done", "status": "ok", "success": True},
+    )
+
+    job = {"cron": "05 10 * * ?", "repeated": True, "enabled": True, "param": {"rooms": [1, 2], "roomCount": 2}}
+    response = await api.create_job(ud, "123456", job)
+    assert response["success"] is True
+    assert response["result"] == "done"
+
+
+def test_hawk_authentication_signs_body(monkeypatch) -> None:
+    """Body-bearing writes sign md5(compact JSON body) in the Hawk payload slot; GET is unchanged."""
+    from roborock import web_api
+
+    monkeypatch.setattr(web_api.time, "time", lambda: 1_700_000_000)
+    monkeypatch.setattr(web_api.secrets, "token_urlsafe", lambda n: "fixednonce")
+    rriot = UserData.from_dict(USER_DATA).rriot
+    assert rriot is not None
+
+    body = {"b": 2, "a": 1}
+    signed = _get_hawk_authentication(rriot, "/p", body=body)
+    unsigned = _get_hawk_authentication(rriot, "/p")
+    formdata_signed = _get_hawk_authentication(rriot, "/p", formdata=body)
+
+    assert signed != unsigned  # the body is actually covered by the MAC
+    assert signed != formdata_signed  # body-signing differs from formdata-signing
+    assert _compact_json(body) == '{"b":2,"a":1}'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #849.

B01 `/jobs` writes fail with `401 auth.err.invalid.token`. This is the REST path for **schedules** and any
deferred/cron job — the one place `/jobs` is the only option (immediate room cleans now have an MQTT route via
#851; *scheduling* a future clean still has to go through `/jobs`). `_get_hawk_authentication` always derives
the Hawk payload slot from `formdata`, which is empty for a JSON body, so the MAC never covers the body the
server receives. GET and bodyless `DELETE /jobs/{id}` are unaffected.

The fix is two coupled parts:
- When a JSON `body` is signed, put `md5(compact-JSON body)` in the payload slot.
- Send those same compact bytes (`data=`), since `json=` re-serializes with spaces and breaks the MAC.

With `body=None`, GET and form-post signing stay byte-identical.

Verified on a Q10 S5+ (`roborock.vacuum.ss07`): with body signing, `POST`/`PUT /jobs` return 200; the current
empty-payload-slot signature returns 401. The official Roborock **iOS app** sends the body **compact** (its
`Content-Length` of 179 equals the no-space serialization, not the longer spaced form), so the exact bytes
must be signed and sent (`data=`, not `json=`). The complete `PUT /jobs` from the iOS app, observed via an
HTTPS proxy — every line in its original order, only sensitive **values** redacted in place (`Authorization`,
`X-UID`, `Cookie`) and device identifiers placeheld:

```
PUT /user/devices/{deviceId}/jobs/{jobId}
Host: api-us.roborock.com
X-IOTSDK-VERSION: 3.4.0_5_09
Accept: */*
Authorization: Hawk id=<redacted>,s=<redacted>,ts=1781315205,nonce=<redacted>,mac=<redacted>
X-APP-NAME: com.roborock.smart
X-UID: <redacted>
Accept-Encoding: gzip, deflate, br
Accept-Language: en-US;q=1, es-US;q=0.9, zh-Hans-US;q=0.8
X-APP-VERSION-CODE: 4.64.02
Content-Type: application/json
Content-Length: 179
User-Agent: com.roborock.smart/4.64.02_2 (iPhone14,8; iOS 26.5; Scale/3.00)
Connection: keep-alive
Cookie: <redacted>
{"cron":"05 10 * * ?","repeated":true,"enabled":true,"param":{"mapId":<mapId>,"cleanRoute":2,"fanLevel":3,"cleanMode":1,"rooms":[],"roomCount":0,"waterLevel":2,"cleanCount":2}}
```

The auth change is generic for any body-bearing write; I've wired one `create_job` consumer in the existing
`get_*` style. Happy to adjust naming or scope in review.

_This is my first PR; AI-assisted, reviewed and refined with care by me: Andrew, a human._
