### PR TITLE
fix: key B01/Q10 RemoteTrait COMMON params by the DP code, not the enum member

### DIFF
--- a/roborock/devices/traits/b01/q10/remote.py
+++ b/roborock/devices/traits/b01/q10/remote.py
@@ -20,7 +20,7 @@ class RemoteTrait:
         self._command = command
 
     async def _send_remote(self, action: RemoteCommand) -> None:
-        await self._command.send(B01_Q10_DP.COMMON, params={B01_Q10_DP.REMOTE: action.value})
+        await self._command.send(B01_Q10_DP.COMMON, params={str(B01_Q10_DP.REMOTE.code): action.value})
 
     async def forward(self) -> None:
         """Move forward."""

--- a/tests/devices/traits/b01/q10/test_remote.py
+++ b/tests/devices/traits/b01/q10/test_remote.py
@@ -27,11 +27,11 @@ def remote_fixture(q10_api: Q10PropertiesApi) -> RemoteTrait:
 @pytest.mark.parametrize(
     ("command_fn", "expected_payload"),
     [
-        (lambda x: x.forward(), {"101": {"dpRemote": 0}}),
-        (lambda x: x.left(), {"101": {"dpRemote": 2}}),
-        (lambda x: x.right(), {"101": {"dpRemote": 3}}),
-        (lambda x: x.stop(), {"101": {"dpRemote": 4}}),
-        (lambda x: x.exit_remote(), {"101": {"dpRemote": 5}}),
+        (lambda x: x.forward(), {"101": {"12": 0}}),
+        (lambda x: x.left(), {"101": {"12": 2}}),
+        (lambda x: x.right(), {"101": {"12": 3}}),
+        (lambda x: x.stop(), {"101": {"12": 4}}),
+        (lambda x: x.exit_remote(), {"101": {"12": 5}}),
     ],
 )
 async def test_remote_commands(


### PR DESCRIPTION
## Summary

`RemoteTrait._send_remote` builds a `dpCommon` (101) payload with
`params={B01_Q10_DP.REMOTE: action.value}` — the inner key is the **enum member**
`B01_Q10_DP.REMOTE`, which serialises to JSON as `"dpRemote"` rather than the DP code
string `"12"`. The B01/Q10 firmware ignores the command when the inner key is the symbolic
name, so all five remote-drive directions (forward / left / right / stop / exit) are silently
inert on hardware.

This is the same key-serialisation class as the REST `/jobs` fix in #852, and `remote.py` is
the one remaining B01/Q10 `dpCommon` write path still keyed by the enum member — the Q10
settings writers (e.g. in #846) already use `{str(dp.code): value}`. The fix is the matching
one-line change.

## Root cause

```python
# Before — inner key serialises to "dpRemote"; firmware ignores it
await self._command.send(B01_Q10_DP.COMMON, params={B01_Q10_DP.REMOTE: action.value})

# After — inner key is "12"; firmware acts on it (matches the {str(dp.code): value} form used elsewhere)
await self._command.send(B01_Q10_DP.COMMON, params={str(B01_Q10_DP.REMOTE.code): action.value})
```

Wire difference (JSON inside `{"dps": ...}`):

| | Before (inert) | After (working) |
|---|---|---|
| forward | `{"101": {"dpRemote": 0}}` | `{"101": {"12": 0}}` |
| left    | `{"101": {"dpRemote": 2}}` | `{"101": {"12": 2}}` |

## Hardware evidence

Validated on a **Roborock Q10 S5+** (`roborock.vacuum.ss07`, B01 device class, firmware 03.11.24):

- Sending `{"101": {"12": N}}` with `N ∈ {0,2,3,4,5}` transitions the device `STATUS` to
  `remote_control_active` (state 7) and the robot physically moves in the commanded direction
  (with voice confirmation).
- The same payload with the enum-member key (`"dpRemote"`) produces no state change and no
  motion — the firmware discards it.
- The official app's own Remote Control wire uses the integer-string inner key
  (`{"101":{"12":N}}`, N = 0/2/3/4/5 for forward/left/right/stop/exit), captured on a session
  we control.

## Tests

`tests/devices/traits/b01/q10/test_remote.py` asserts the constructed wire payload for all five
directions; it expected the old (broken) `"dpRemote"` key. This PR updates the five expected
values to `"12"` to match the correct wire form. All five pass — no hardware needed (a
`FakeChannel` records the published message and the test `json.loads` it). The drive behaviour
above can't be reproduced in CI without live hardware.

## Files changed

- `roborock/devices/traits/b01/q10/remote.py` — one-line fix in `_send_remote`.
- `tests/devices/traits/b01/q10/test_remote.py` — five expected-payload strings `"dpRemote"` → `"12"`.

---

Thanks for maintaining this library — and for the recent Q10 work. Happy to share the wire
captures or the validation methodology on request.
