### PR TITLE
feat: add QV 35A dock type code (21) to RoborockDockTypeCode

### DIFF
--- a/roborock/data/v1/v1_code_mappings.py
+++ b/roborock/data/v1/v1_code_mappings.py
@@ -664,6 +664,7 @@ class RoborockDockTypeCode(RoborockEnum):
     saros_r10_dock = 16
     qrevo_curv_dock = 17
     saros_10_dock = 18
+    qv_35a_dock = 21
     qrevo_s5v_dock = 22
     saros_20_dock = 27
 

--- a/roborock/device_features.py
+++ b/roborock/device_features.py
@@ -653,6 +653,7 @@ WASH_N_FILL_DOCK_TYPES = [
     RoborockDockTypeCode.qrevo_s_dock,
     RoborockDockTypeCode.saros_r10_dock,
     RoborockDockTypeCode.qrevo_curv_dock,
+    RoborockDockTypeCode.qv_35a_dock,
     RoborockDockTypeCode.qrevo_s5v_dock,
     RoborockDockTypeCode.saros_20_dock,
 ]

--- a/tests/data/v1/test_v1_containers.py
+++ b/tests/data/v1/test_v1_containers.py
@@ -272,6 +272,15 @@ def test_qrevo_s5v_dock_type():
     assert s.dock_type.value == 22
 
 
+def test_qv_35a_dock_type():
+    """Test that dock type code 21 (Roborock QV 35A dock) is properly recognized."""
+    modified_status = STATUS.copy()
+    modified_status["dock_type"] = 21
+    s = S7MaxVStatus.from_dict(modified_status)
+    assert s.dock_type == RoborockDockTypeCode.qv_35a_dock
+    assert s.dock_type.value == 21
+
+
 def test_multi_maps_list_info(snapshot: SnapshotAssertion) -> None:
     """Test that MultiMapsListInfo can be deserialized correctly."""
     data = {

--- a/tests/devices/traits/v1/test_dust_collection_mode.py
+++ b/tests/devices/traits/v1/test_dust_collection_mode.py
@@ -29,6 +29,7 @@ def dust_collection_mode_trait(
         (RoborockDockTypeCode.s8_dock),
         (RoborockDockTypeCode.p10_dock),
         (RoborockDockTypeCode.qrevo_s_dock),
+        (RoborockDockTypeCode.qv_35a_dock),
         (RoborockDockTypeCode.qrevo_s5v_dock),
         (RoborockDockTypeCode.saros_20_dock),
     ],

--- a/tests/devices/traits/v1/test_smart_wash_params.py
+++ b/tests/devices/traits/v1/test_smart_wash_params.py
@@ -30,6 +30,7 @@ def smart_wash_params_trait(
         (RoborockDockTypeCode.s8_dock),
         (RoborockDockTypeCode.p10_dock),
         (RoborockDockTypeCode.qrevo_s_dock),
+        (RoborockDockTypeCode.qv_35a_dock),
         (RoborockDockTypeCode.qrevo_s5v_dock),
         (RoborockDockTypeCode.saros_20_dock),
     ],

--- a/tests/devices/traits/v1/test_wash_towel_mode.py
+++ b/tests/devices/traits/v1/test_wash_towel_mode.py
@@ -31,6 +31,7 @@ def wash_towel_mode_trait(
         (RoborockDockTypeCode.s8_dock),
         (RoborockDockTypeCode.p10_dock),
         (RoborockDockTypeCode.qrevo_s_dock),
+        (RoborockDockTypeCode.qv_35a_dock),
         (RoborockDockTypeCode.qrevo_s5v_dock),
         (RoborockDockTypeCode.saros_20_dock),
     ],


### PR DESCRIPTION
## Summary

Adds dock type `21` — the wash/fill/dry dock shipped with the **Roborock QV 35A** (`roborock.vacuum.a168`) — to `RoborockDockTypeCode` and to `WASH_N_FILL_DOCK_TYPES`.

This mirrors #829 (which added the Qrevo S5V, `22`).

Fixes #864.

## Why

The QV 35A's dock reports `dock_type: 21`, which had no enum member, so `RoborockDockTypeCode(21)` fell back to `unknown`. That made `is_wash_n_fill_dock()` return `False`, which skips the `wash_towel_mode` trait at setup (`Trait 'wash_towel_mode' not supported, skipping`). Downstream in Home Assistant, the clean-water-box, dirty-water-box and strainer entities are gated on `wash_towel_mode is not None`, so they were permanently `unavailable` — even though the device reports the underlying data (`dss` for the tank statuses, `strainer_work_times` in the consumables payload).

Verified on a real QV 35A (firmware `02.36.38`): after adding the dock type, `is_wash_n_fill_dock` is `True` and the trait is set up as expected. Clean-fluid delivery is not supported on this dock (`is_clean_fluid_delivery_supported = False`), so the `clean_fluid_empty` entity correctly remains absent.

## Changes

- `roborock/data/v1/v1_code_mappings.py`: add `qv_35a_dock = 21`.
- `roborock/device_features.py`: add `RoborockDockTypeCode.qv_35a_dock` to `WASH_N_FILL_DOCK_TYPES`.
- Tests: a dedicated `test_qv_35a_dock_type`, plus the new dock type added to the `wash_towel_mode` / `dust_collection_mode` / `smart_wash_params` trait parametrizations — same coverage #829 added.

## Testing

```
pytest tests/data/ tests/devices/traits/v1/test_wash_towel_mode.py \
       tests/devices/traits/v1/test_dust_collection_mode.py \
       tests/devices/traits/v1/test_smart_wash_params.py \
       tests/test_supported_features.py tests/devices/traits/v1/test_device_features.py
```

All pass (snapshots unchanged).
