### PR TITLE
fix: enable Qrevo Master wash/fill dock features (code 14 dock, Roborock QRevo S5A) 

### DIFF
--- a/roborock/device_features.py
+++ b/roborock/device_features.py
@@ -650,6 +650,7 @@ WASH_N_FILL_DOCK_TYPES = [
     RoborockDockTypeCode.p10_dock,
     RoborockDockTypeCode.p10_pro_dock,
     RoborockDockTypeCode.s8_maxv_ultra_dock,
+    RoborockDockTypeCode.qrevo_master_dock,
     RoborockDockTypeCode.qrevo_s_dock,
     RoborockDockTypeCode.saros_r10_dock,
     RoborockDockTypeCode.qrevo_curv_dock,

--- a/tests/devices/traits/v1/test_device_features.py
+++ b/tests/devices/traits/v1/test_device_features.py
@@ -3,8 +3,9 @@
 import pytest
 from syrupy import SnapshotAssertion
 
-from roborock.data import HomeDataDevice
+from roborock.data import HomeDataDevice, RoborockDockTypeCode
 from roborock.data.v1.v1_containers import ConsumableField, StatusField
+from roborock.device_features import is_wash_n_fill_dock
 from roborock.devices.device import RoborockDevice
 from roborock.devices.traits.v1.consumeable import ConsumableTrait
 from roborock.devices.traits.v1.status import StatusTrait
@@ -13,6 +14,11 @@ from tests import mock_data
 V1_DEVICES = {
     k: HomeDataDevice.from_dict(device) for k, device in mock_data.DEVICES.items() if device.get("pv") == "1.0"
 }
+
+
+def test_qrevo_master_dock_is_wash_n_fill_dock() -> None:
+    """Test that the Qrevo Master dock supports wash and fill features."""
+    assert is_wash_n_fill_dock(RoborockDockTypeCode.qrevo_master_dock)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds `RoborockDockTypeCode.qrevo_master_dock` to `WASH_N_FILL_DOCK_TYPES` so dock type `14` is treated as a wash/fill dock.

I noticed that with the HA 2026.7 update, by Qrevo S5A dock stopped showing the tank entities and strainer entity.

## Why

HA 2026.7 diagnostics show a Qrevo Master dock reporting `dockType: 14`, which maps to `RoborockDockTypeCode.qrevo_master_dock`. The same dock reports wash-capable data, but `python-roborock` currently excludes it from `WASH_N_FILL_DOCK_TYPES`, so `is_wash_n_fill_dock()` returns `False`.

That causes the V1 `wash_towel_mode` trait to be skipped. Downstream in Home Assistant, `wash_towel_mode is not None` gates the clean-water, dirty-water, and strainer entities, so those entities can become stale/restored for this dock even though the underlying dock data is available.

Sanitized diagnostics comparison:

```text
dockType 14: dss=168, strainerWorkTimes=44, wash_towel_mode absent, smart_wash_params absent
dockType 15: dss=169, strainerWorkTimes=34, wash_towel_mode present, smart_wash_params present
```

## Changes

- `roborock/device_features.py`: add `qrevo_master_dock` to `WASH_N_FILL_DOCK_TYPES`.
- `tests/devices/traits/v1/test_device_features.py`: add a focused regression test proving `is_wash_n_fill_dock(RoborockDockTypeCode.qrevo_master_dock)` is true.

## Testing

```bash
uv run pytest tests/devices/traits/v1/test_device_features.py
uv run pytest tests/devices/traits/v1/test_wash_towel_mode.py tests/devices/traits/v1/test_smart_wash_params.py
uv run pre-commit run --all-files
uv run pytest
```
