### PR TITLE
feat: truncate large payloads in RoborockMessage __repr__

### DIFF
--- a/roborock/roborock_message.py
+++ b/roborock/roborock_message.py
@@ -274,6 +274,9 @@ ROBOROCK_DATA_CONSUMABLE_PROTOCOL = [
 ]
 
 
+MAX_PAYLOAD_REPR_LEN = 1024
+
+
 @dataclass
 class RoborockMessage:
     protocol: RoborockMessageProtocol
@@ -282,3 +285,18 @@ class RoborockMessage:
     version: bytes = b"1.0"
     random: int = field(default_factory=lambda: get_next_int(10000, 99999))
     timestamp: int = field(default_factory=lambda: get_timestamp())
+
+    def __repr__(self) -> str:
+        payload_repr = "None"
+        if self.payload is not None:
+            if isinstance(self.payload, (bytes, bytearray, str)) and len(self.payload) > MAX_PAYLOAD_REPR_LEN:
+                r = repr(self.payload[:MAX_PAYLOAD_REPR_LEN])
+                quote = r[-1]
+                payload_repr = f"{r[:-1]}...{quote} (length: {len(self.payload)})"
+            else:
+                payload_repr = repr(self.payload)
+        return (
+            f"RoborockMessage(protocol={self.protocol}, payload={payload_repr}, "
+            f"seq={self.seq}, version={self.version!r}, random={self.random}, "
+            f"timestamp={self.timestamp})"
+        )

--- a/tests/test_roborock_message.py
+++ b/tests/test_roborock_message.py
@@ -2,7 +2,7 @@ import json
 
 from freezegun import freeze_time
 
-from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
+from roborock.roborock_message import MAX_PAYLOAD_REPR_LEN, RoborockMessage, RoborockMessageProtocol
 
 
 def test_roborock_message() -> None:
@@ -23,3 +23,50 @@ def test_roborock_message() -> None:
     assert message1.seq != message2.seq
     assert message1.random != message2.random
     assert message1.timestamp > message2.timestamp
+
+
+def test_roborock_message_repr() -> None:
+    """Test custom __repr__ of RoborockMessage truncates long payloads."""
+    # 1. Payload is None
+    msg_none = RoborockMessage(
+        protocol=RoborockMessageProtocol.RPC_REQUEST,
+        payload=None,
+        seq=123456,
+        version=b"1.0",
+        random=12345,
+        timestamp=1700000000,
+    )
+    assert repr(msg_none) == (
+        "RoborockMessage(protocol=101, payload=None, seq=123456, version=b'1.0', random=12345, timestamp=1700000000)"
+    )
+
+    # 2. Payload is short (<= MAX_PAYLOAD_REPR_LEN bytes)
+    short_payload = b"a" * MAX_PAYLOAD_REPR_LEN
+    msg_short = RoborockMessage(
+        protocol=RoborockMessageProtocol.RPC_REQUEST,
+        payload=short_payload,
+        seq=123456,
+        version=b"1.0",
+        random=12345,
+        timestamp=1700000000,
+    )
+    assert repr(msg_short) == (
+        f"RoborockMessage(protocol=101, payload={repr(short_payload)}, seq=123456, "
+        "version=b'1.0', random=12345, timestamp=1700000000)"
+    )
+
+    # 3. Payload is long (> MAX_PAYLOAD_REPR_LEN bytes)
+    long_payload = b"a" * (MAX_PAYLOAD_REPR_LEN + 10)
+    msg_long = RoborockMessage(
+        protocol=RoborockMessageProtocol.RPC_REQUEST,
+        payload=long_payload,
+        seq=123456,
+        version=b"1.0",
+        random=12345,
+        timestamp=1700000000,
+    )
+    expected_payload_repr = f"b'{'a' * MAX_PAYLOAD_REPR_LEN}...' (length: {MAX_PAYLOAD_REPR_LEN + 10})"
+    assert repr(msg_long) == (
+        f"RoborockMessage(protocol=101, payload={expected_payload_repr}, seq=123456, "
+        "version=b'1.0', random=12345, timestamp=1700000000)"
+    )


### PR DESCRIPTION
This PR introduces a custom `__repr__` implementation for `RoborockMessage` that truncates payloads (bytes, bytearray, str) exceeding 1024 bytes (defined by `MAX_PAYLOAD_REPR_LEN`). This prevents large map binary messages from bloating and clogging the debug logs.