### PR TITLE
chore: limit aiohttp for dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dev = [
     # Pull in the CLI dependencies so maintainers can run the `roborock`
     # command and pdoc can import roborock.cli for docs generation.
     "python-roborock[cli]",
+    # aioresponses is not compatible with aiohttp 3.14 yet. https://github.com/pnuckowski/aioresponses/issues/289
+    "aiohttp>=3.8.2,<3.14",
     "pytest-asyncio>=1.1.0",
     "pytest",
     "pre-commit>=3.5,<5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1359,6 +1359,7 @@ cli = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiohttp" },
     { name = "aioresponses" },
     { name = "codespell" },
     { name = "freezegun" },
@@ -1394,6 +1395,7 @@ provides-extras = ["cli"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiohttp", specifier = ">=3.8.2,<3.14" },
     { name = "aioresponses", specifier = ">=0.7.7,<0.8" },
     { name = "codespell" },
     { name = "freezegun", specifier = ">=1.5.1,<2" },


### PR DESCRIPTION
aioresponses does not yet support the newest version of aiohttp, so a fresh install of a unbounded dependency will install conflicting versions.