### PR TITLE
fix: Correct reset consumable parameters for strainer and cleaning brush

### DIFF
--- a/roborock/devices/traits/v1/consumeable.py
+++ b/roborock/devices/traits/v1/consumeable.py
@@ -30,8 +30,8 @@ class ConsumableAttribute(StrEnum):
     FILTER_WORK_TIME = "filter_work_time"
     SIDE_BRUSH_WORK_TIME = "side_brush_work_time"
     MAIN_BRUSH_WORK_TIME = "main_brush_work_time"
-    STRAINER_WORK_TIME = "strainer_work_time"
-    CLEANING_BRUSH_WORK_TIME = "cleaning_brush_work_time"
+    STRAINER_WORK_TIME = "strainer_work_times"
+    CLEANING_BRUSH_WORK_TIME = "cleaning_brush_work_times"
 
     @classmethod
     def from_str(cls, value: str) -> Self:

--- a/tests/devices/traits/v1/test_consumable.py
+++ b/tests/devices/traits/v1/test_consumable.py
@@ -51,8 +51,8 @@ async def test_get_consumable_data_success(consumable_trait: ConsumableTrait, mo
         (ConsumableAttribute.SIDE_BRUSH_WORK_TIME, "side_brush_work_time"),
         (ConsumableAttribute.FILTER_WORK_TIME, "filter_work_time"),
         (ConsumableAttribute.SENSOR_DIRTY_TIME, "sensor_dirty_time"),
-        (ConsumableAttribute.STRAINER_WORK_TIME, "strainer_work_time"),
-        (ConsumableAttribute.CLEANING_BRUSH_WORK_TIME, "cleaning_brush_work_time"),
+        (ConsumableAttribute.STRAINER_WORK_TIME, "strainer_work_times"),
+        (ConsumableAttribute.CLEANING_BRUSH_WORK_TIME, "cleaning_brush_work_times"),
     ],
 )
 async def test_reset_consumable_data(

--- a/tests/testing/test_v1_simulator.py
+++ b/tests/testing/test_v1_simulator.py
@@ -53,6 +53,8 @@ async def test_trait_consumable_reset():
 
     await device.v1_properties.consumables.refresh()
     assert device.v1_properties.consumables.filter_work_time == 74384
+    assert device.v1_properties.consumables.strainer_work_times == 65
+    assert device.v1_properties.consumables.cleaning_brush_work_times == 66
 
     # Reset the filter consumable through the trait API
     await device.v1_properties.consumables.reset_consumable(ConsumableAttribute.FILTER_WORK_TIME)
@@ -61,6 +63,16 @@ async def test_trait_consumable_reset():
     assert fake_device.consumables.filter_work_time == 0
     # The trait auto-refreshes after reset, so the client should reflect the change
     assert device.v1_properties.consumables.filter_work_time == 0
+
+    # Reset the strainer consumable through the trait API
+    await device.v1_properties.consumables.reset_consumable(ConsumableAttribute.STRAINER_WORK_TIME)
+    assert fake_device.consumables.strainer_work_times == 0
+    assert device.v1_properties.consumables.strainer_work_times == 0
+
+    # Reset the cleaning brush consumable through the trait API
+    await device.v1_properties.consumables.reset_consumable(ConsumableAttribute.CLEANING_BRUSH_WORK_TIME)
+    assert fake_device.consumables.cleaning_brush_work_times == 0
+    assert device.v1_properties.consumables.cleaning_brush_work_times == 0
 
 
 async def test_trait_dnd_refresh():


### PR DESCRIPTION
The vacuum firmware expects the parameter in the `reset_consumable` command to match the internal property keys exactly. For the dock strainer and cleaning brush, these keys are plural:
* `strainer_work_times`
* `cleaning_brush_work_times`

Currently, `ConsumableAttribute` defines them as singular (`strainer_work_time` and `cleaning_brush_work_time`). Because of this, the library sends singular parameters when resetting them, which the vacuum firmware silently ignores.

This PR:
1. Updates the values of `ConsumableAttribute.STRAINER_WORK_TIME` and `ConsumableAttribute.CLEANING_BRUSH_WORK_TIME` to their correct plural forms (`strainer_work_times` and `cleaning_brush_work_times`).
2. Corrects the unit tests and integration/simulator tests to expect and verify the correct plural parameters.

Fixes Home Assistant Core Issue: https://github.com/home-assistant/core/issues/175672
